### PR TITLE
Get CMGTools to compile in 76X

### DIFF
--- a/RootTools/interface/RecoilCorrector.h
+++ b/RootTools/interface/RecoilCorrector.h
@@ -35,6 +35,7 @@ class RecoilCorrector
 {
   
 public:
+  RecoilCorrector() { /* empty constructor only for ROOT dictionaries */ }
   RecoilCorrector(string iNameZDat, int iSeed=0xDEADBEEF);
   RecoilCorrector(string iNameZDat1, string iPrefix, int iSeed=0xDEADBEEF);
   ~RecoilCorrector();

--- a/RootTools/src/classes.h
+++ b/RootTools/src/classes.h
@@ -2,6 +2,6 @@
 
 namespace {
   namespace {
-    RecoilCorrector recoilCorrector(string nameFileToCorrect, int iSeed);
+    RecoilCorrector recoilCorrector;
   }
 }

--- a/VVResonances/src/FastJetInterface.cc
+++ b/VVResonances/src/FastJetInterface.cc
@@ -288,18 +288,18 @@ std::vector<double> FastJetInterface::nSubJettiness(unsigned int i ,int NMAX,uns
   
   fastjet::contrib::NormalizedMeasure          normalizedMeasure        (beta,R0);
   fastjet::contrib::UnnormalizedMeasure        unnormalizedMeasure      (beta);
-  fastjet::contrib::GeometricMeasure           geometricMeasure         (beta);
+  //fastjet::contrib::GeometricMeasure           geometricMeasure         (beta);
   fastjet::contrib::NormalizedCutoffMeasure    normalizedCutoffMeasure  (beta,R0,Rcutoff);
   fastjet::contrib::UnnormalizedCutoffMeasure  unnormalizedCutoffMeasure(beta,Rcutoff);
-  fastjet::contrib::GeometricCutoffMeasure     geometricCutoffMeasure   (beta,Rcutoff);
+  //fastjet::contrib::GeometricCutoffMeasure     geometricCutoffMeasure   (beta,Rcutoff);
 
   fastjet::contrib::MeasureDefinition const * measureDef = 0;
   switch ( measureDefinition ) {
   case UnnormalizedMeasure : measureDef = &unnormalizedMeasure; break;
-  case GeometricMeasure    : measureDef = &geometricMeasure; break;
+  //case GeometricMeasure    : measureDef = &geometricMeasure; break;
   case NormalizedCutoffMeasure : measureDef = &normalizedCutoffMeasure; break;
   case UnnormalizedCutoffMeasure : measureDef = &unnormalizedCutoffMeasure; break;
-  case GeometricCutoffMeasure : measureDef = &geometricCutoffMeasure; break;
+  //case GeometricCutoffMeasure : measureDef = &geometricCutoffMeasure; break;
   case NormalizedMeasure : default : measureDef = &normalizedMeasure; break;
   } 
 


### PR DESCRIPTION
Based on `cbernet/heppy_7_6_3` and with all subsystems from #1 , the code compiles with these few small changes.

@bachtis you will have to have a look at 351adc9
