### PR TITLE
catch the ImportError of cmsIO for 80X

### DIFF
--- a/Production/python/eostools.py
+++ b/Production/python/eostools.py
@@ -17,7 +17,13 @@ def setCAFPath():
     if caf not in sys.path:
         sys.path.append(caf)
 setCAFPath()
-import cmsIO
+try:
+    import cmsIO
+except ImportError as e:
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.warning(str(e))
+    logger.warning("wasn't able to import cmsIO, which this job might not need unless it uses EOS.")
 
 def runXRDCommand(path, cmd, *args):
     """Run an xrd command.


### PR DESCRIPTION
In `eostools.py`, `cmsIO` is imported. The file `cmsIO.py` is located on the AFS at `/afs/cern.ch/cms/caf/python`. Jobs fail with an import error unless they run on the machine with the AFS.

However, jobs don't need `cmsIO` or `eostools` unless they use EOS.

This PR catches the import error and continue.
