### PR TITLE
ttHHeavyFlavourHadronAnalyzer memory leak workaround

### DIFF
--- a/TTHAnalysis/python/analyzers/ttHHeavyFlavourHadronAnalyzer.py
+++ b/TTHAnalysis/python/analyzers/ttHHeavyFlavourHadronAnalyzer.py
@@ -15,8 +15,6 @@ class ttHHeavyFlavourHadronAnalyzer( Analyzer ):
         self.readCollections( event.input )
         if not self.cfg_comp.isMC: return True
 
-        def ref2id(ref):
-            return (ref.id().processIndex(), ref.id().productIndex(), ref.key()) if ref else (0,0,0)
         def flav(gp):
             id = abs(gp.pdgId())
             return max((id/1000) % 10, (id/100) % 10)
@@ -28,8 +26,8 @@ class ttHHeavyFlavourHadronAnalyzer( Analyzer ):
                 if mom.status() != 2 or abs(mom.pdgId()) < 100 and abs(mom.pdgId()) != 15: break
                 if same(bhadron,mom):
                     return True
-                mom = mom.motherRef() if mom.numberOfMothers() > 0 else None
-                if mom == None or mom.isNull() or not mom.isAvailable(): break
+                mom = mom.mother() if mom.numberOfMothers() > 0 else None
+                if not mom: break
             return False
 
         heavyHadrons = []
@@ -45,13 +43,13 @@ class ttHHeavyFlavourHadronAnalyzer( Analyzer ):
             if not lastInChain: continue
             if myflav == 4:
                 heaviestInChain = True
-                mom = g.motherRef() if g.numberOfMothers() > 0 else None
-                while mom != None and mom.isNonnull() and mom.isAvailable():
+                mom = g.mother() if g.numberOfMothers() > 0 else None
+                while mom:
                     if mom.status() != 2 or abs(mom.pdgId()) < 100: break
                     if flav(mom) == 5:
                         heaviestInChain = False
                         break
-                    mom = mom.motherRef() if mom.numberOfMothers() > 0 else None
+                    mom = mom.mother() if mom.numberOfMothers() > 0 else None
                     if not heaviestInChain: continue
             # OK, here we are
             g.flav = myflav
@@ -119,15 +117,15 @@ class ttHHeavyFlavourHadronAnalyzer( Analyzer ):
         for had in heavyHadrons:
             had.sourceId = 0
             srcmass = 0
-            mom = had.motherRef() if had.numberOfMothers() > 0 else None
-            while mom != None and mom.isNonnull() and mom.isAvailable():
+            mom = had.mother() if had.numberOfMothers() > 0 else None
+            while mom:
                 if mom.status() > 2: 
                     if mom.mass() > srcmass:
                         srcmass = mom.mass()
                         had.sourceId = mom.pdgId() 
                     if srcmass > 175:
                         break
-                mom = mom.motherRef() if mom.numberOfMothers() > 0 else None
+                mom = mom.mother() if mom.numberOfMothers() > 0 else None
         # sort and save
         heavyHadrons.sort(key = lambda h : h.pt(), reverse=True)
         event.genHeavyHadrons = heavyHadrons


### PR DESCRIPTION
use `GenParticle::mother` instead of `GenParticle::motherRef` to avoid the memory leak as per https://github.com/CERN-PH-CMG/cmg-cmssw/pull/642
Note: this removes the check that the ref is available, which _should_ always be the case but I'm not 100% sure of it.
