### PR TITLE
80x minimal fixes and fast MET skimmer

### DIFF
--- a/TTHAnalysis/python/analyzers/ntupleTypes.py
+++ b/TTHAnalysis/python/analyzers/ntupleTypes.py
@@ -166,8 +166,6 @@ jetTypeSusyExtra = NTupleObjectType("jetSusyExtra",  baseObjectTypes = [ jetType
 
 fatJetType = NTupleObjectType("fatJet",  baseObjectTypes = [ jetType ], variables = [
     NTupleVariable("prunedMass",  lambda x : x.userFloat("ak8PFJetsCHSPrunedMass"),  float, help="pruned mass"),
-    NTupleVariable("trimmedMass", lambda x : x.userFloat("ak8PFJetsCHSTrimmedMass"), float, help="trimmed mass"),
-    NTupleVariable("filteredMass", lambda x : x.userFloat("ak8PFJetsCHSFilteredMass"), float, help="filtered mass"),
     NTupleVariable("softDropMass", lambda x : x.userFloat("ak8PFJetsCHSSoftDropMass"), float, help="trimmed mass"),
     NTupleVariable("tau1", lambda x : x.userFloat("NjettinessAK8:tau1"), float, help="1-subjettiness"),
     NTupleVariable("tau2", lambda x : x.userFloat("NjettinessAK8:tau2"), float, help="2-subjettiness"),

--- a/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
+++ b/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
@@ -333,18 +333,22 @@ jetAna = cfg.Analyzer(
 
 ## Jets Analyzer (generic)
 jetAnaScaleUp = jetAna.clone(name='jetAnalyzerScaleUp',
+    copyJetsByValue = True,
     jetCol = 'slimmedJets',
     shiftJEC = +1, # set to +1 or -1 to apply +/-1 sigma shift to the nominal jet energies
     collectionPostFix = "_jecUp",
     calculateType1METCorrection  = True,
+    cleanSelectedLeptons = False,
    )
 
 ## Jets Analyzer (generic)
 jetAnaScaleDown = jetAna.clone(name='jetAnalyzerScaleDown',
+    copyJetsByValue = True,
     jetCol = 'slimmedJets',
     shiftJEC = -1, # set to +1 or -1 to apply +/-1 sigma shift to the nominal jet energies
     collectionPostFix = "_jecDown",
     calculateType1METCorrection  = True,
+    cleanSelectedLeptons = False,
     )
 
 ##PFcharged jets analyzer

--- a/TTHAnalysis/python/analyzers/ttHCoreEventAnalyzer.py
+++ b/TTHAnalysis/python/analyzers/ttHCoreEventAnalyzer.py
@@ -161,6 +161,7 @@ class ttHCoreEventAnalyzer( Analyzer ):
         objects30 = [ j for j in event.cleanJets if j.pt() > 30 ] + event.selectedLeptons
         objects40 = [ j for j in event.cleanJets if j.pt() > 40 ] + event.selectedLeptons
         objectsX  = [ j for j in event.cleanJets if j.pt() > self.jetPt ] + event.selectedLeptons
+        objects25j = [ j for j in event.cleanJets if j.pt() > 25 ] 
         objects40j = [ j for j in event.cleanJets if j.pt() > 40 ] 
         objects50j = [ j for j in event.cleanJets if j.pt() > 50 ] 
         objectsXj = [ j for j in event.cleanJets if j.pt() > self.jetPt ]
@@ -199,6 +200,7 @@ class ttHCoreEventAnalyzer( Analyzer ):
         event.mhtJetX = event.mhtJetXvec.pt()
         event.mhtPhiJetX = event.mhtJetXvec.phi()
 
+        event.htJet25j = sum([x.pt() for x in objects25j])
         event.htJet40j = sum([x.pt() for x in objects40j])
         event.mhtJet40jvec = ROOT.reco.Particle.LorentzVector(-1.*(sum([x.px() for x in objects40j])) , -1.*(sum([x.py() for x in objects40j])), 0, 0 )               
         event.mhtJet40j = event.mhtJet40jvec.pt()

--- a/TTHAnalysis/python/analyzers/ttHFastMETSkimmer.py
+++ b/TTHAnalysis/python/analyzers/ttHFastMETSkimmer.py
@@ -1,0 +1,28 @@
+from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
+from PhysicsTools.Heppy.analyzers.core.AutoHandle import AutoHandle
+
+class ttHFastMETSkimmer( Analyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(ttHFastMETSkimmer,self).__init__(cfg_ana,cfg_comp,looperName)
+        self.metCut = self.cfg_ana.metCut
+
+    def declareHandles(self):
+        super(ttHFastMETSkimmer, self).declareHandles()
+        self.handles['met'] = AutoHandle(self.cfg_ana.met,"std::vector<pat::MET>")            
+
+    def beginLoop(self, setup):
+        super(ttHFastMETSkimmer,self).beginLoop(setup)
+        self.counters.addCounter('events')
+        self.count = self.counters.counter('events')
+        self.count.register('all events')
+        self.count.register('accepted events')
+
+
+    def process(self, event):
+        self.readCollections( event.input )
+        self.count.inc('all events')
+       
+        if self.handles['met'].product().front().pt() > self.metCut :
+             self.count.inc('accepted events')
+             return True
+        return False


### PR DESCRIPTION
Minimal fixes for 80X: remove missing fatJet variables, fix some defaults for the scaled up and down jets, compute htJet25 also without leptons.
Also, add a module to cut on the met directly from miniAOD, for fast skimming.
A 76X backport will be made for the relevant parts.
