### PR TITLE
Production tool updates (80X)

### DIFF
--- a/Production/scripts/cmgListChunksToResub
+++ b/Production/scripts/cmgListChunksToResub
@@ -19,6 +19,11 @@ if [[ "$1" == "-t" ]]; then
     echo "# Will test for the presence of file $F "
 fi;
 
+LOC=0
+if [[ "$1" == "-l" ]]; then
+    LOC=1; shift;
+fi;
+
 Q=8nh
 if [[ "$1" == "-q" ]]; then
     Q=$2; shift; shift;
@@ -45,7 +50,11 @@ echo "# Will print out the commands to resubmit the chunks that failed "
 for D in *_Chunk[0-9]*; do
     if test \! -s $D/$F; then
         if [[ "${LSFL}" == "0"  ]] || find $D -maxdepth 1 -type d -name 'LSFJOB_*' | grep -q LSFJ; then
-            echo "cmgResubChunk -q $Q ${BASE}${D} "; 
+            if [[ "$LOC" == "1" ]]; then
+                echo "cmgRunChunkLocally ${BASE}${D} "; 
+            else
+                echo "cmgResubChunk -q $Q ${BASE}${D} "; 
+            fi
         else
             echo "# Chunk ${BASE}${D} does not have a LSFJOB directory, maybe still running? "; 
         fi;
@@ -56,7 +65,11 @@ if [[ "$Z" != "0" ]]; then
     for Z in $(cmgListZombies  "*_Chunk[0-9]*/$F"); do
         if test -s $Z; then # empty files have already been found
             D=${Z%%/*};
-            echo "cmgResubChunk -q $Q ${BASE}${D}    # zombie";
+            if [[ "$LOC" == "1" ]]; then
+                echo "cmgRunChunkLocally ${BASE}${D}     # zombie"; 
+            else
+                echo "cmgResubChunk -q $Q ${BASE}${D}    # zombie";
+            fi
         fi;
     done
 fi;

--- a/Production/scripts/cmgRunChunkLocally
+++ b/Production/scripts/cmgRunChunkLocally
@@ -1,4 +1,5 @@
 #!/bin/bash
+BG=true; if [[ "$1" == "-f" ]]; then BG=false; shift; fi;
 test -f $1/batchScript.sh || echo "Missing $1/batchScript.sh";
 test -f $1/batchScript.sh || exit 1;
 
@@ -9,5 +10,10 @@ export LS_SUBCWD=$PWD
 cd /tmp
 WORK=$(mktemp --tmpdir -d chunk-${NAME}-XXXXXXXXXX)
 cd $WORK
-( bash $LS_SUBCWD/batchScript.sh > log.txt 2>&1 & )
-echo "Running: look at $WORK/log.txt"
+if $BG; then
+    ( bash $LS_SUBCWD/batchScript.sh > log.txt 2>&1 & )
+    echo "Running: look at $WORK/log.txt"
+else
+    echo "Running in $WORK"
+    bash $LS_SUBCWD/batchScript.sh 2>&1 | tee log.txt
+fi

--- a/RootTools/python/samples/ComponentCreator.py
+++ b/RootTools/python/samples/ComponentCreator.py
@@ -165,7 +165,7 @@ class ComponentCreator(object):
             )
         component.json = json
         component.vetoTriggers = vetoTriggers
-        component.dataset_entries = self.getPrimaryDatasetEntries(dataset,user,pattern)
+        component.dataset_entries = self.getPrimaryDatasetEntries(dataset,user,pattern,run_range=run_range)
         component.dataset = dataset
         component.run_range = run_range
         return component
@@ -178,9 +178,9 @@ class ComponentCreator(object):
         if useAAA: mapping = 'root://cms-xrd-global.cern.ch/%s'
         return [ mapping % f for f in files]
 
-    def getPrimaryDatasetEntries(self, dataset, user, pattern, useAAA=False):
+    def getPrimaryDatasetEntries(self, dataset, user, pattern, useAAA=False, run_range=None):
         # print 'getting files for', dataset,user,pattern
-        ds = createDataset( user, dataset, pattern, True )
+        ds = createDataset( user, dataset, pattern, True, run_range=run_range )
         return ds.primaryDatasetEntries
 
     def getMyFiles(self, dataset, user, pattern, dbsInstance, useAAA=False):


### PR DESCRIPTION
- do only one summary query to DAS and get both the number of events and number of files out of it, instead of doing two identical queries
- for datasets built with a run range, get the correct number of entries and not that of the full run range (important if one configures splitting as function of number of events)
- minor improvements to cmgListChunksToResub and cmgRunChunkLocally
