### PR TITLE
Added N_ISR jets to event for SUSY signal model systematics

### DIFF
--- a/TTHAnalysis/python/analyzers/nIsrAnalyzer.py
+++ b/TTHAnalysis/python/analyzers/nIsrAnalyzer.py
@@ -1,0 +1,38 @@
+from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
+from PhysicsTools.HeppyCore.utils.deltar import deltaR2
+import math
+
+##__________________________________________________________________||
+class NIsrAnalyzer(Analyzer):
+
+    def process(self, event):
+
+        #Can only be performed on MC
+        if not self.cfg_comp.isMC: return True
+
+        event.nIsr = 0
+
+        for jet in event.cleanJetsAll:
+
+            if jet.pt()<30.0: continue
+            if abs(jet.eta())>2.4: continue
+            matched = False
+            for mc in event.genParticles:
+                if matched: break
+                if (mc.status()!=23 or abs(mc.pdgId())>5): continue
+                momid = abs(mc.mother().pdgId())
+                if not (momid==6 or momid==23 or momid==24 or momid==25 or momid>1e6): continue
+                    #check against daughter in case of hard initial splitting
+                for idau in range(mc.numberOfDaughters()):
+                    dR = math.sqrt(deltaR2(jet.eta(),jet.phi(), mc.daughter(idau).p4().eta(),mc.daughter(idau).p4().phi()))
+                    if dR<0.3:
+                        matched = True
+                        break
+            if not matched:
+                event.nIsr+=1
+        pass
+
+        return True
+ 
+
+##__________________________________________________________________||


### PR DESCRIPTION
Added the N_ISR analyzer here instead of in generic code as in https://github.com/CERN-PH-CMG/cmg-cmssw/pull/667

The N_ISR variable for ISR signal model systematics was introduced in a SUSY meeting in the following talk: https://indico.cern.ch/event/557678/contributions/2247944/attachments/1311994/1963568/16-07-19_ana_manuelf_isr.pdf

A sample of code was provided by @manuelfs in: https://github.com/manuelfs/babymaker/blob/0136340602ee28caab14e3f6b064d1db81544a0a/bmaker/plugins/bmaker_full.cc#L1268-L1295

This has been converted to python and implemented in the here.
