### PR TITLE
80X few small updates to general tools

### DIFF
--- a/RootTools/python/samples/autoAAAconfig.py
+++ b/RootTools/python/samples/autoAAAconfig.py
@@ -9,7 +9,7 @@ def autoAAA(selectedComponents):
         if not re.match("/[^/]+/[^/]+/MINIAOD(SIM)?", comp.dataset): continue
         if "/store/" not in comp.files[0]: continue
         if re.search("/store/(group|user|cmst3)/", comp.files[0]): continue
-        if comp.isData and "PromptReco" in comp.dataset: continue
+        #if comp.isData and "PromptReco" in comp.dataset: continue
         if not tier2Checker.available(comp.dataset):
             print "Dataset %s is not available, will use AAA" % comp.dataset
             changeComponentAccessMode.convertComponent(comp, "root://cms-xrd-global.cern.ch/%s")

--- a/TTHAnalysis/python/tools/vertexWeightFriend.py
+++ b/TTHAnalysis/python/tools/vertexWeightFriend.py
@@ -7,6 +7,7 @@ class VertexWeightFriend:
         self.myvals = self.load(myfile,myhist)
         self.targetvals = self.load(targetfile,targethist)
         self.vtxCollectionInEvent = vtx_coll_to_reweight
+        self.warned = False
         def w2(t,m):
             if t == 0: return (0 if m else 1)
             return (t/m if m else 1)
@@ -55,9 +56,15 @@ class VertexWeightFriend:
     def listBranches(self):
         return [ (self.name,'F') ]
     def __call__(self,event):
-        nvtx = int(getattr(event,self.vtxCollectionInEvent))
-        weight = self.weights[nvtx] if nvtx < len(self.weights) else 1
-        return { self.name: weight }
+        if hasattr(event,self.vtxCollectionInEvent):
+            nvtx = int(getattr(event,self.vtxCollectionInEvent))
+            weight = self.weights[nvtx] if nvtx < len(self.weights) else 1
+            return { self.name: weight }
+        else:
+            if not self.warned:
+                print "WARNING! Variable ",self.vtxCollectionInEvent," is missing in the tree. Setting the weight to 1."
+                self.warned = True
+            return { self.name: 1 }
 
 if __name__ == '__main__':
     from sys import argv


### PR DESCRIPTION
- in autoAAAconfig, re-enable the possibility to run using AAA on data PromptReco. Very useful for data not subscribed to CERN T2 (e.g. SingleElectron)
- in vertexWeightFriend, add the possibility to set weight 1 when using a variable which is not in the trees (use case is nTrueInt that is there only in MC) and when running this together to other modules in the friend producer
