### PR TITLE
Production improvements

### DIFF
--- a/Production/python/hadd.py
+++ b/Production/python/hadd.py
@@ -82,7 +82,7 @@ def haddRec(odir, idirs):
             hadd('/'.join([root, file]), odir, idirs)
 
 
-def haddChunks(idir, removeDestDir, cleanUp=False, ignoreDirs=None):
+def haddChunks(idir, removeDestDir, cleanUp=False, ignoreDirs=None, maxSize=None):
 
     chunks = {}
     compsToSpare = set()
@@ -93,44 +93,54 @@ def haddChunks(idir, removeDestDir, cleanUp=False, ignoreDirs=None):
         # print filepath
         if os.path.isdir(filepath):
             compdir = file
-            skipDir = False
-            if compdir in ignoreDirs:
-              ignoreDirs.remove(compdir) 
-              skipDir = True
             try:
                 prefix,num = compdir.rsplit('_Chunk',1)
             except ValueError:
                 # ok, not a chunk
                 continue
             #print prefix, num
-            if skipDir: 
-              compsToSpare.add(prefix)
-              continue
+            if compdir in ignoreDirs:
+                ignoreDirs.remove(compdir)
+                compsToSpare.add(prefix)
+                continue
             chunks.setdefault( prefix, list() ).append(filepath)
     if len(chunks)==0:
         print 'warning: no chunk found.'
         return
-    for comp, cchunks in chunks.iteritems():
-        odir = '/'.join( [idir, comp] )
-        print odir, cchunks
-        if removeDestDir:
-            if os.path.isdir( odir ):
-                shutil.rmtree(odir)
-        haddRec(odir, cchunks)
     if cleanUp:
         chunkDir = 'Chunks'
         if os.path.isdir('Chunks'):
             shutil.rmtree(chunkDir)
         os.mkdir(chunkDir)
-        print chunks
-        for comp, chunks in chunks.iteritems():
-            cleanIt = True
-            if comp in compsToSpare :
-              cleanIt = False
-              compsToSpare.remove(comp)
-            if cleanIt :
-              for chunk in chunks:
-                  shutil.move(chunk, chunkDir)
+    for comp, cchunks in chunks.iteritems():
+        odir = '/'.join( [idir, comp] )
+        tasks = [ (odir,cchunks) ]
+        if maxSize:
+            threshold = maxSize*(1024.**3)
+            #print odir, cchunks
+            running = [ dict(files=[], size=0.) ]
+            for ch in cchunks:
+                size = os.path.getsize(ch)
+                if running[-1]['size'] + size > threshold:
+                    running.append(dict(files=[], size=0.))
+                running[-1]['files'].append(ch)
+                running[-1]['size'] += size
+            if len(running) > 1:
+                tasks = []
+                for i,task in enumerate(running):
+                    tasks.append( ("%s_part%d" % (odir,i+1), task['files'][:]) )
+                    print "Part %s: %d files, %.3f Gb" % (tasks[-1][0], len(task['files']), task['size']/(1024.**3))
+            else:
+                print "Entire chunk %.3f Gb, below threshold" % (running[-1]['size']/(1024.**3))
+        for odir, cchunks in tasks:
+            #print odir, cchunks
+            if removeDestDir:
+                if os.path.isdir( odir ):
+                    shutil.rmtree(odir)
+            haddRec(odir, cchunks)
+            if cleanUp and (comp not in compsToSpare):
+                for chunk in cchunks:
+                    shutil.move(chunk, chunkDir)
 
 
 

--- a/Production/python/hadd.py
+++ b/Production/python/hadd.py
@@ -12,7 +12,11 @@ def haddPck(file, odir, idirs):
     for dir in idirs:
         fileName = file.replace( idirs[0], dir )
         pckfile = open(fileName)
-        obj = pickle.load(pckfile)
+        try:
+            obj = pickle.load(pckfile)
+        except:
+            print "Error loading pckfile "+fileName
+            raise
         if sum is None:
             sum = obj
         else:

--- a/Production/scripts/cmgListChunksToResub
+++ b/Production/scripts/cmgListChunksToResub
@@ -29,6 +29,12 @@ if [[ "$1" == "-l" ]]; then
     LOC=1; shift;
 fi;
 
+P=false
+if [[ "$1" == "-p" ]]; then
+    $TERSE || echo "# Will also check for null pck files"
+    P=true; shift;
+fi;
+
 Q=8nh
 if [[ "$1" == "-q" ]]; then
     Q=$2; shift; shift;
@@ -53,8 +59,10 @@ fi
 
 $TERSE || echo "# Will print out the commands to resubmit the chunks that failed "
 for D in *_Chunk[0-9]*; do
-    if test \! -s $D/$F; then
-        if [[ "${LSFL}" == "0"  ]] || find $D -maxdepth 1 -type d -name 'LSFJOB_*' | grep -q LSFJ; then
+    PCKBAD=false
+    ${P} && find $D -name '*.pck' -empty | grep -q pck && PCKBAD=true; 
+    if test \! -s $D/$F || $PCKBAD; then
+        if [[ "${LSFL}" == "0"  ]] || find $D -maxdepth 1 -type d -name 'LSFJOB_*' | grep -q LSFJ || test -f $D/submission_failed ; then
             if [[ "$LOC" == "1" ]]; then
                 echo "cmgRunChunkLocally ${BASE}${D} ";
 	    else

--- a/Production/scripts/cmgResubChunk
+++ b/Production/scripts/cmgResubChunk
@@ -19,4 +19,5 @@ elif test \! -f batchScript.sh; then
 fi
 LAB="$(basename $PWD)"; if [[ "$1" != "" ]]; then LAB=$1; fi;
 rename LSFJ OLD_LSFJ *; 
+test -f submission_failed && rm submission_failed
 bsub -q $Q -J $LAB < batchScript.sh

--- a/Production/scripts/cmgRunChunkLocally
+++ b/Production/scripts/cmgRunChunkLocally
@@ -6,6 +6,7 @@ test -f $1/batchScript.sh || exit 1;
 cd $1
 NAME=$(basename $PWD)
 rename LSFJ OLD_LSFJ *; 
+test -f submission_failed && rm submission_failed
 export LS_SUBCWD=$PWD
 cd /tmp
 WORK=$(mktemp --tmpdir -d chunk-${NAME}-XXXXXXXXXX)

--- a/Production/scripts/haddChunks.py
+++ b/Production/scripts/haddChunks.py
@@ -23,6 +23,9 @@ if __name__ == '__main__':
     parser.add_option("-c","--clean", dest="clean",
                       default=False,action="store_true",
                       help="move chunks to Chunks/ after processing.")
+    parser.add_option("--max-size", dest="maxSize",
+                      default=None,type="float",
+                      help="max size of a chunk (in Gb)")
 
     (options,args) = parser.parse_args()
 
@@ -32,5 +35,5 @@ if __name__ == '__main__':
 
     dir = args[0]
 
-    haddChunks(dir, options.remove, options.clean)
+    haddChunks(dir, options.remove, options.clean, maxSize=options.maxSize)
 


### PR DESCRIPTION
* some improvements to `cmgListChunksToResub`, `cmgRunChunkLocally`, `cmgResubChunk` (useful only after https://github.com/CERN-PH-CMG/cmg-cmssw/pull/678)
* add an optional maximum output size for haddChunk (will create Sample_part1 ... Sample_partN if the output would be too large), better error messages for corrupt pck files, and move the Chunks in the Chunks directory after each sample (so, if one sample fails, the previous ones that succeeded are already cleaned up)