### PR TITLE
Updates and soft-b stop search

### DIFF
--- a/Production/python/hadd.py
+++ b/Production/python/hadd.py
@@ -120,7 +120,7 @@ def haddChunks(idir, removeDestDir, cleanUp=False, ignoreDirs=None, maxSize=None
             #print odir, cchunks
             running = [ dict(files=[], size=0.) ]
             for ch in cchunks:
-                size = os.path.getsize(ch)
+                size = sum(sum(os.path.getsize(os.path.join(p,f)) for f in fs) for p,d,fs in os.walk(ch))
                 if running[-1]['size'] + size > threshold:
                     running.append(dict(files=[], size=0.))
                 running[-1]['files'].append(ch)

--- a/TTHAnalysis/cfg/run_susyStopSoftB_cfg.py
+++ b/TTHAnalysis/cfg/run_susyStopSoftB_cfg.py
@@ -116,6 +116,7 @@ treeProducer = cfg.Analyzer(
 
 
 ## For non-signal
+susyScanAna.useLumiInfo = False
 if True:
     susyCoreSequence.remove(lheWeightAna)
     del treeProducer.collections["LHE_weights"]
@@ -143,6 +144,7 @@ from CMGTools.RootTools.samples.samples_13TeV_80X_susySignalsPriv import *
 from CMGTools.RootTools.samples.samples_13TeV_DATA2016 import *
 
 #what = "SR" 
+what = "CRWc" 
 what = "CR2L" 
 
 ## ==== MC: 2L CR ====
@@ -177,29 +179,62 @@ elif what == "CR2L":
     susyCoreSequence.insert(susyCoreSequence.index(skimAnalyzer)+1, fastSkim)
     #mcSamples = [ TTJets, TBar_tWch, T_tWch, TBarToLeptons_tch_powheg, TToLeptons_tch_powheg,
     #              WJetsToLNu, DYJetsToLL_M10to50, DYJetsToLL_M50, WWTo2L2Nu, WZTo3LNu ]
-    mcSamples = [ TTJets_LO, TTLep_powUEP8M2, TTSemi_powUEP8M2 ] #, DYJetsToLL_M10to50, DYJetsToLL_M10to50_LO, DY1JetsToLL_M10to50, DY2JetsToLL_M10to50 ]
+    #mcSamples = [ TTJets_LO, TTLep_powUEP8M2, TTSemi_powUEP8M2 ] #, DYJetsToLL_M10to50, DYJetsToLL_M10to50_LO, DY1JetsToLL_M10to50, DY2JetsToLL_M10to50 ]
     #jetAna.mcGT = "Spring16_FastSimV1_MC"
     #jetAna.applyL2L3Residual = False
-    autoAAA(mcSamples)
+    #autoAAA(mcSamples)
     cropToLumi(mcSamples,50) 
     #mcSamples = WNJets
     configureSplittingFromTime(mcSamples, 12, 2)
     #configureSplittingFromTime(WNJets, 5, 1)
     dataSamples = [ ]; vetoTrig = []
     for name, trig in ("MuonEG",triggers_mue),: # ("DoubleMu",triggers_mumu), ("DoubleEG",triggers_ee):#, ("SingleMu", triggers_1mu_iso), ("SingleEl", triggers_1e):
-        for d in [ MuonEG_Run2016G_PromptReco_v1 ]: #MuonEG_more: #29Jul2016: #dataSamples_Run2016C_v2 + dataSamples_Run2016D_v2 :
+        for d in [ MuonEG_Run2016H_PromptReco_v2 ]:#dataSamples_23Sep2016PlusPrompt: 
             if name in d.name: 
                 d.triggers = trig[:]; d.vetoTriggers = vetoTrig[:]
                 dataSamples.append(d)
         vetoTrig += trig
     configureSplittingFromTime(dataSamples, 10, 1, maxFiles=15)
     #configureSplittingFromTime([d for d in dataSamples if "Single" in d.name], 8, 2)
+elif what == "CRWc":
+    ttHFastMETSkim.metCut = 30
+    ttHJetMETSkim.metCut  = 30 
+    ttHLepSkim.minLeptons = 1
+    from CMGTools.TTHAnalysis.analyzers.ttHFastLepSkimmer import ttHFastLepSkimmer
+    fastSkim = cfg.Analyzer(
+        ttHFastLepSkimmer, name="ttHFastLepSkimmer",
+        muons = 'slimmedMuons', muCut = lambda mu : mu.pt() > 20 and mu.isLooseMuon(),
+        electrons = 'slimmedElectrons', eleCut = lambda ele : ele.pt() > 20,
+        minLeptons = 1,
+    )
+    susyCoreSequence.insert(susyCoreSequence.index(skimAnalyzer)+1, fastSkim)
+    #mcSamples = [ TTJets, TBar_tWch, T_tWch, TBarToLeptons_tch_powheg, TToLeptons_tch_powheg,
+    #              WJetsToLNu, DYJetsToLL_M10to50, DYJetsToLL_M50, WWTo2L2Nu, WZTo3LNu ]
+    #mcSamples = [ TTJets_LO, TTLep_powUEP8M2, TTSemi_powUEP8M2 ] #, DYJetsToLL_M10to50, DYJetsToLL_M10to50_LO, DY1JetsToLL_M10to50, DY2JetsToLL_M10to50 ]
+    mcSamples = [ WJetsToLNu_reHLT  ]#, TTJets, DYJetsToLL_M10to50, DYJetsToLL_M50, QCD_Mu15 ]
+    #jetAna.mcGT = "Spring16_FastSimV1_MC"
+    #jetAna.applyL2L3Residual = False
+    autoAAA(mcSamples)
+    cropToLumi(mcSamples,2.5) 
+    #mcSamples = WNJets
+    configureSplittingFromTime(mcSamples, 12, 1)
+    #configureSplittingFromTime(WNJets, 5, 1)
+    dataSamples = [ ]; vetoTrig = []
+    for name, trig in ("SingleMu", triggers_1mu_iso),("SingleEl", triggers_1e),: # ("DoubleMu",triggers_mumu), ("DoubleEG",triggers_ee):#, ("MuonEG",triggers_mue),("SingleEl", triggers_1e):
+        for d in [SingleMuon_Run2016G_23Sep2016]:#[ SingleMuon_Run2016H_PromptReco_v2, SingleElectron_Run2016G_23Sep2016, SingleElectron_Run2016H_PromptReco_v2 ]: #MuonEG_more: #29Jul2016: #dataSamples_Run2016C_v2 + dataSamples_Run2016D_v2 :
+            if name in d.name: 
+                d.triggers = trig[:]; d.vetoTriggers = vetoTrig[:]
+                dataSamples.append(d)
+        vetoTrig += trig
+    configureSplittingFromTime(dataSamples, 10, 1.5, maxFiles=15)
+    #configureSplittingFromTime([d for d in dataSamples if "Single" in d.name], 8, 2)
+
 
 for d in dataSamples:
-    d.json = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Cert_271036-280385_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt'
+    d.json = '/afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON_NoL1T.txt'
     if "PromptReco" in d.dataset: filterPromptRecoComponent(d,verbose=0)
 
-selectedComponents = mcSamples # [mcSamplesMap["ZJetsToNuNu_HT800t1200"]]#sigSamples # dataSamples # mcSamples #
+selectedComponents = dataSamples # [mcSamplesMap["ZJetsToNuNu_HT800t1200"]]#sigSamples # dataSamples # mcSamples #
 
 
 #-------- SEQUENCE -----------

--- a/TTHAnalysis/python/analyzers/ntupleTypes.py
+++ b/TTHAnalysis/python/analyzers/ntupleTypes.py
@@ -251,7 +251,24 @@ svType = NTupleObjectType("sv", baseObjectTypes = [ fourVectorType ], variables 
     NTupleVariable("secDxyTracks", lambda x : x.secDxyTracks, help="second highest |dxy| of vertex tracks"),
     NTupleVariable("maxD3dTracks", lambda x : x.maxD3dTracks, help="highest |ip3D| of vertex tracks"),
     NTupleVariable("secD3dTracks", lambda x : x.secD3dTracks, help="second highest |ip3D| of vertex tracks"),
-
+])
+svTypeExtra = NTupleObjectType("svExtra", baseObjectTypes = [ svType ], variables = [
+    NTupleVariable("tk1_pt",  lambda x : x.daughter(0).pt() if x.numberOfDaughters() > 0 else -999, help="pt of first track"),
+    NTupleVariable("tk1_eta",  lambda x : x.daughter(0).eta() if x.numberOfDaughters() > 0 else -999, help="eta of first track"),
+    NTupleVariable("tk1_phi",  lambda x : x.daughter(0).phi() if x.numberOfDaughters() > 0 else -999, help="phi of first track"),
+    NTupleVariable("tk1_charge",  lambda x : x.daughter(0).charge() if x.numberOfDaughters() > 0 else -999, int, help="charge of first track"),
+    NTupleVariable("tk2_pt",  lambda x : x.daughter(1).pt() if x.numberOfDaughters() > 1 else -999, help="pt of second track"),
+    NTupleVariable("tk2_eta",  lambda x : x.daughter(1).eta() if x.numberOfDaughters() > 1 else -999, help="eta of second track"),
+    NTupleVariable("tk2_phi",  lambda x : x.daughter(1).phi() if x.numberOfDaughters() > 1 else -999, help="phi of second track"),
+    NTupleVariable("tk2_charge",  lambda x : x.daughter(1).charge() if x.numberOfDaughters() > 1 else -999, int, help="charge of second track"),
+    NTupleVariable("tk3_pt",  lambda x : x.daughter(2).pt() if x.numberOfDaughters() > 2 else -999, help="pt of third track"),
+    NTupleVariable("tk3_eta",  lambda x : x.daughter(2).eta() if x.numberOfDaughters() > 2 else -999, help="eta of third track"),
+    NTupleVariable("tk3_phi",  lambda x : x.daughter(2).phi() if x.numberOfDaughters() > 2 else -999, help="phi of third track"),
+    NTupleVariable("tk3_charge",  lambda x : x.daughter(2).charge() if x.numberOfDaughters() > 2 else -999, int, help="charge of third track"),
+    NTupleVariable("tk4_pt",  lambda x : x.daughter(0).pt() if x.numberOfDaughters() > 0 else -999, help="pt of fourth track"),
+    NTupleVariable("tk4_eta",  lambda x : x.daughter(3).eta() if x.numberOfDaughters() > 3 else -999, help="eta of fourth track"),
+    NTupleVariable("tk4_phi",  lambda x : x.daughter(3).phi() if x.numberOfDaughters() > 3 else -999, help="phi of fourth track"),
+    NTupleVariable("tk4_charge",  lambda x : x.daughter(3).charge() if x.numberOfDaughters() > 3 else -999, int, help="charge of fourth track"),
 ])
 
 heavyFlavourHadronType = NTupleObjectType("heavyFlavourHadron", baseObjectTypes = [ genParticleType ], variables = [

--- a/TTHAnalysis/python/analyzers/treeProducerSusyStopSoftB.py
+++ b/TTHAnalysis/python/analyzers/treeProducerSusyStopSoftB.py
@@ -54,7 +54,7 @@ susyStopSoftB_collections.update({
     #"recoveredJets"    : NTupleCollection("RecJet", jetTypeSusy, 15, help="Jets recovered declustering in the jet-lepton cleaning"),
     #"recoveredSplitJets" : NTupleCollection("RecSplitJet", jetTypeSusy, 15, help="Jets recovered declustering in the jet-lepton cleaning, split"),
     ##------------------------------------------------
-    "ivf"       : NTupleCollection("SV",     svType, 20, help="SVs from IVF"),
+    "ivf"       : NTupleCollection("SV",     svTypeExtra, 20, help="SVs from IVF"),
     "genBHadrons"  : NTupleCollection("GenBHad", heavyFlavourHadronType, 20, mcOnly=True, help="Gen-level B hadrons"),
     "genDHadrons"  : NTupleCollection("GenDHad", heavyFlavourHadronType, 20, mcOnly=True, help="Gen-level D hadrons"),
     ##------------------------------------------------

--- a/TTHAnalysis/python/plotter/skimTrees.py
+++ b/TTHAnalysis/python/plotter/skimTrees.py
@@ -138,7 +138,9 @@ if __name__ == "__main__":
         for tty in mca._allData[proc]:
             print "\t component %-40s" % tty.cname()
             myoutpath = outdir+"/"+tty.cname()
-            mysource  = options.path+"/"+tty.cname()
+            for path in options.path:
+                mysource  = path+"/"+tty.cname()
+                if os.path.exists(mysource): break
             mycut = tty.adaptExpr(cut.allCuts(),cut=True)
             if options.doS2V: mycut  = scalarToVector(mycut)
             if options.pretend: continue

--- a/TTHAnalysis/python/plotter/susy-stopSoftB/cuts-CR2L.txt
+++ b/TTHAnalysis/python/plotter/susy-stopSoftB/cuts-CR2L.txt
@@ -1,3 +1,4 @@
+# vim: syntax=sh
 dilep OS   : nLepGood >= 2 && LepGood1_charge * LepGood2_charge < 0
 25/20      : LepGood1_pt > 25 && LepGood2_pt > 20
 met30      : met_pt > 30
@@ -18,7 +19,7 @@ mll12      : mass_2(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_mass,LepGood2
 sip6       : max(LepGood1_sip3d,LepGood2_sip3d) < 6
 eMu        : abs(LepGood1_pdgId) != abs(LepGood2_pdgId)
 #lepMVA     : min(LepGood1_mvaTTH,LepGood2_mvaTTH) > 0.0
-minProjMet40: met_pt*min(if3(cos(met_phi-LepGood1_phi)>0, abs(sin(met_phi-LepGood1_phi)), 1),  if3(cos(met_phi-LepGood2_phi)>0, abs(sin(met_phi-LepGood2_phi)), 1) ) > 40; Disable=True
+#minProjMet40: met_pt*min(if3(cos(met_phi-LepGood1_phi)>0, abs(sin(met_phi-LepGood1_phi)), 1),  if3(cos(met_phi-LepGood2_phi)>0, abs(sin(met_phi-LepGood2_phi)), 1) ) > 40; Disable=True
 
 soft_mu_pt: LepOtherGood_pt[0] < 20; Disable=True
 #soft_mu_id: LepOtherGood_mediumMuonId[0] > 0; Disable=True # NO, unneeded

--- a/TTHAnalysis/python/plotter/susy-stopSoftB/cuts-CRWc.txt
+++ b/TTHAnalysis/python/plotter/susy-stopSoftB/cuts-CRWc.txt
@@ -1,0 +1,41 @@
+mu_fiducial : abs(LepGood1_pdgId) == 13 && LepGood1_pt > 30 && abs(LepGood1_eta) < 2.1
+met30       : met_pt > 30
+1l          : nLepGood == 1
+tight       : LepGood1_sip3d < 4 && LepGood1_miniRelIso < 0.1
+#leadBJet   : Jet1_pt > 30 && Jet1_btagCSV > 0.80
+#fwdJetVeto : Sum$(JetFwd_pt > 40) == 0
+
+#oneSV: Sum$(abs(SV_dxy)<2 && SV_cosTheta > 0.98 && SV_ntracks >= 3 && SV_sip3d > 4)
+tagJet_pt   : JetGood_pt[0] > 30; Disable=True
+#tagJet_btag : JetGood_btagCSV[0] > 0.80
+#zeroJets_20  : Alt$(JetGood_pt[0],19.9) < 20; Disable=True
+jetVeto_40  : Alt$(JetGood_pt[1],20) < 40; Disable=True
+
+#bVeto20 : Sum$(JetGood_btagCSV > 0.46) <= 1
+#zeroJets_20  : nJetGood <= 1
+#oneLep : nLepOtherGood >= 1; Disable=True
+
+#mll12      : mass_2(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_mass,LepGood2_pt,LepGood2_eta,LepGood2_phi,LepGood2_mass) > 12
+#ptll30     : pt_2(LepGood1_pt,LepGood1_phi,LepGood2_pt,LepGood2_phi) > 30
+#sip6       : max(LepGood1_sip3d,LepGood2_sip3d) < 6
+#eMu        : abs(LepGood1_pdgId) != abs(LepGood2_pdgId)
+#lepMVA     : min(LepGood1_mvaTTH,LepGood2_mvaTTH) > 0.0
+#minProjMet40: met_pt*min(if3(cos(met_phi-LepGood1_phi)>0, abs(sin(met_phi-LepGood1_phi)), 1),  if3(cos(met_phi-LepGood2_phi)>0, abs(sin(met_phi-LepGood2_phi)), 1) ) > 40; Disable=True
+
+#soft_mu_pt: LepOtherGood_pt[0] < 20; Disable=True
+#soft_mu_id: LepOtherGood_mediumMuonId[0] > 0; Disable=True # NO, unneeded
+#soft_mu_sip: LepOtherGood_sip3d[0] > 3; Disable=True
+#soft_mu_ai : LepOtherGood_miniRelIso[0] > 0.2; Disable=True
+mtWwin: 50 < mt_2(LepGood1_pt,LepGood1_phi,met,met_phi) && mt_2(LepGood1_pt,LepGood1_phi,met,met_phi)  < 130; Disable=True
+
+SV_0: abs(SV_dxy)<2 && SV_cosTheta > 0.98; Disable=True
+SV_nt3 : SV_ntracks >= 3; Disable=True
+SV_sip4 : SV_sip3d > 4; Disable=True
+SV_pt20: SV_jetPt < 20; Disable=True
+#SV_pt40: SV_jetPt < 40 && (SV_jetPt < 20 || SV_jetBTagCSV < 0.46); Disable=True
+SV_pt3 : SV_pt > 3; Disable=True
+SV_pt5 : SV_pt > 5; Disable=True
+SV_drLep : deltaR(SV_eta,SV_phi,LepGood1_eta,LepGood1_phi) > 0.2; Disable=True
+SV_inJet : deltaR(SV_eta,SV_phi,Jet_eta[iJetGood[0]],Jet_phi[iJetGood[0]]) < 0.4; Disable=True
+
+#mu_other : abs(LepOther_pdgId) == 13 && deltaR(LepOther_eta,LepOther_phi,JetGood_eta,JetGood_phi) > 0.4 && abs(LepOther_dz) < 0.2; Disable=True

--- a/TTHAnalysis/python/plotter/susy-stopSoftB/ec-minimal.txt
+++ b/TTHAnalysis/python/plotter/susy-stopSoftB/ec-minimal.txt
@@ -1,0 +1,6 @@
+ -K met_pt -K met_phi -K nVert -K genWeight -K xsec
+ -K nLepGood -K LepGood_pt -K LepGood_eta  -K LepGood_phi -K LepGood_pdgId  -K LepGood_dxy -K LepGood_dz -K LepGood_sip3d -K LepGood_relIso03  -K LepGood_miniRelIso  -K LepGood_mediumMuonId
+ -K nLepOther -K LepOther_pt -K LepOther_eta  -K LepOther_phi -K LepOther_pdgId  -K LepOther_dxy -K LepOther_dz -K LepOther_sip3d -K LepOther_relIso03   -K LepGood_miniRelIso  -K LepGood_mediumMuonId
+ -K nJet -K Jet_pt -K Jet_eta -K Jet_phi -K Jet_mass -K Jet_btagCSV -K Jet_ctagCsvL  -K Jet_ctagCsvB -K Jet_hadronFlavour
+ -K nJetFwd -K JetFwd_pt -K JetFwd_eta -K JetFwd_mass -K JetFwd_phi 
+ -K nSV -K SV_*

--- a/TTHAnalysis/python/plotter/susy-stopSoftB/env
+++ b/TTHAnalysis/python/plotter/susy-stopSoftB/env
@@ -10,16 +10,16 @@ SR)
         *) P=/afs/cern.ch/user/g/gpetrucc/w/TREES_80X_StopSoftB_180616/${WHAT}/v2 ;;
     esac;
     ;;
-2L)
+CR2L)
     case $HOSTNAME in
-        cmsco01.cern.ch) P=/data/gpetrucc/TREES_80X_StopSoftB_180616/${WHAT}/skim ;;
-        *) P=/afs/cern.ch/user/g/gpetrucc/w/TREES_80X_StopSoftB_180616/${WHAT}_SkimDY/ ;;
+        cmsco01.cern.ch) P=/data/gpetrucc/TREES_80X_SusyStopSoftB_181116/${WHAT} ;;
+        *) P=/afs/cern.ch/user/g/gpetrucc/w/TREES_80X_SusyStopSoftB_181116/${WHAT} ;;
     esac;
-    OPTS="${OPTS}  --Fs {P}/1_recleaner_v0 --Fs {P}/2_leprecleaner_v1 "
+    OPTS="${OPTS}  --Fs {P}/1_recleaner_v3 --Fs {P}/2_leprecleaner_v3 "
     if [[ "$1" != "-" ]]; then
         OPTS="${OPTS}  susy-stopSoftB/mca-CR2L-Spring16.txt susy-stopSoftB/cuts-CR2L.txt "
     fi;
-    if [[ "$1" == "G" ]]; then OPTS="${OPTS} -l 6.3"; fi
+    if [[ "$1" != "G" ]]; then OPTS="${OPTS} -l 36.2"; fi
     ;;
 esac;
 

--- a/TTHAnalysis/python/plotter/susy-stopSoftB/functionsWc.cc
+++ b/TTHAnalysis/python/plotter/susy-stopSoftB/functionsWc.cc
@@ -1,0 +1,27 @@
+#include <cmath>
+#include "Math/GenVector/LorentzVector.h"
+#include "Math/GenVector/PtEtaPhiM4D.h"
+#include "Math/GenVector/PxPyPzM4D.h"
+
+//// UTILITY FUNCTIONS NOT IN TFORMULA ALREADY
+
+float m_D_Kpp(float qpt1, float eta1, float qpt2, float eta2, float phi12, float qpt3, float eta3, float phi13) {
+    typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > PtEtaPhiMVector;
+    float m1 = 0.1396, m2 = 0.1396, m3 = 0.1396;
+    float qtot = qpt1*qpt2*qpt3;
+    if      (qtot*qpt1 > 0) m1 = 0.4937;
+    else if (qtot*qpt2 > 0) m2 = 0.4937;
+    else if (qtot*qpt3 > 0) m3 = 0.4937;
+    PtEtaPhiMVector p41(std::abs(qpt1),eta1,0.0,  m1);
+    PtEtaPhiMVector p42(std::abs(qpt2),eta2,phi12,m2);
+    PtEtaPhiMVector p43(std::abs(qpt3),eta3,phi13,m3);
+    return (p41+p42+p43).M();
+}
+
+
+void functionsWc() {}
+
+
+
+
+

--- a/TTHAnalysis/python/plotter/susy-stopSoftB/mca-CR2L-Spring16.txt
+++ b/TTHAnalysis/python/plotter/susy-stopSoftB/mca-CR2L-Spring16.txt
@@ -38,20 +38,11 @@ WJets : W2JetsToLNu_LO: xsec : 1 ; FillColor=ROOT.kGray+2, Label="W+jets" #, Nor
 WJets : W3JetsToLNu_LO: xsec : 1 ; FillColor=ROOT.kGray+2, Label="W+jets" #, NormSystematic=0.5
 WJets : W4JetsToLNu_LO: xsec : 1 ; FillColor=ROOT.kGray+2, Label="W+jets" #, NormSystematic=0.5
 
-# data : DoubleEG_Run2016B_PromptReco_v2
-# data : DoubleEG_Run2016C_PromptReco_v2
-# data : DoubleEG_Run2016D_PromptReco_v2
-# data : MuonEG_Run2016B_PromptReco_v2
-# data : MuonEG_Run2016C_PromptReco_v2
-# data : MuonEG_Run2016D_PromptReco_v2
-# data : DoubleMuon_Run2016B_PromptReco_v2
-# data : DoubleMuon_Run2016C_PromptReco_v2
-# data : DoubleMuon_Run2016D_PromptReco_v2
-
-# 12.9
-# data : MuonEG_Run2016B_29Jul2016
-# data : MuonEG_Run2016C_29Jul2016
-# data : MuonEG_Run2016D_29Jul2016
-
-# 6.3
-data : MuonEG_Run2016G_PromptReco_v1
+data : MuonEG_Run2016B_23Sep2016
+data : MuonEG_Run2016C_23Sep2016
+data : MuonEG_Run2016D_23Sep2016
+data : MuonEG_Run2016E_23Sep2016
+data : MuonEG_Run2016F_23Sep2016
+data : MuonEG_Run2016G_23Sep2016
+data : MuonEG_Run2016H_PromptReco_v2
+data : MuonEG_Run2016H_PromptReco_v3

--- a/TTHAnalysis/python/plotter/susy-stopSoftB/mca-CRWc-Spring16.txt
+++ b/TTHAnalysis/python/plotter/susy-stopSoftB/mca-CRWc-Spring16.txt
@@ -1,0 +1,25 @@
+
+# vim: syntax=sh
+* ; TreeName="treeProducerStopSoftB"
+
+WJets : WJetsToLNu_reHLT_part2 + WJetsToLNu_reHLT_part3 : xsec : 1
+#WJets : WJetsToLNu_LO_reHLT_part1 + WJetsToLNu_LO_reHLT_part2 + WJetsToLNu_LO_reHLT_part3 + WJetsToLNu_LO_reHLT_part4 + WJetsToLNu_LO_reHLT_part5: xsec : 1 ; FillColor=ROOT.kGray+1, Label="W+jets" #, NormSystematic=0.5
+#WJets_cSV : WJetsToLNu_LO_reHLT_part1 + WJetsToLNu_LO_reHLT_part2 + WJetsToLNu_LO_reHLT_part3 + WJetsToLNu_LO_reHLT_part4 + WJetsToLNu_LO_reHLT_part5: xsec : SV_mcMatchFraction > 0.66 && SV_mcFlavHeaviest == 4 ; FillColor=ROOT.kAzure+1, Label="W+j\, c" #, NormSystematic=0.5
+#WJets_bcSV : WJetsToLNu_LO_reHLT_part1 + WJetsToLNu_LO_reHLT_part2 + WJetsToLNu_LO_reHLT_part3 + WJetsToLNu_LO_reHLT_part4 + WJetsToLNu_LO_reHLT_part5: xsec : SV_mcMatchFraction > 0.66 && SV_mcFlavHeaviest >= 5 && SV_mcFlavFirst == 4 ; FillColor=ROOT.kViolet+1,   Label="W+j\, b\#rightarrowc" #, NormSystematic=0.5
+#WJets_bSV : WJetsToLNu_LO_reHLT_part1 + WJetsToLNu_LO_reHLT_part2 + WJetsToLNu_LO_reHLT_part3 + WJetsToLNu_LO_reHLT_part4 + WJetsToLNu_LO_reHLT_part5: xsec : SV_mcMatchFraction > 0.66 && SV_mcFlavHeaviest >= 5 && SV_mcFlavFirst > 4 ; FillColor=ROOT.kRed+1,   Label="W+j\, b" #, NormSystematic=0.5
+#WJets_oSV : WJetsToLNu_LO_reHLT_part1 + WJetsToLNu_LO_reHLT_part2 + WJetsToLNu_LO_reHLT_part3 + WJetsToLNu_LO_reHLT_part4 + WJetsToLNu_LO_reHLT_part5: xsec : SV_mcMatchFraction <=0.66 || SV_mcFlavHeaviest <  4 ; FillColor=ROOT.kGray+0,  Label="W+j\, other" #, NormSystematic=0.5
+#WJets_cJ : WJetsToLNu_LO_reHLT_part1 + WJetsToLNu_LO_reHLT_part2 + WJetsToLNu_LO_reHLT_part3 + WJetsToLNu_LO_reHLT_part4 + WJetsToLNu_LO_reHLT_part5: xsec : abs(JetGood_hadronFlavour[0]) == 4; FillColor=ROOT.kViolet+1,   Label="W+j\, c" #, NormSystematic=0.5
+#WJets_bJ : WJetsToLNu_LO_reHLT_part1 + WJetsToLNu_LO_reHLT_part2 + WJetsToLNu_LO_reHLT_part3 + WJetsToLNu_LO_reHLT_part4 + WJetsToLNu_LO_reHLT_part5: xsec : abs(JetGood_hadronFlavour[0]) == 5; FillColor=ROOT.kRed+1,   Label="W+j\, b" #, NormSystematic=0.5
+#WJets_oJ : WJetsToLNu_LO_reHLT_part1 + WJetsToLNu_LO_reHLT_part2 + WJetsToLNu_LO_reHLT_part3 + WJetsToLNu_LO_reHLT_part4 + WJetsToLNu_LO_reHLT_part5: xsec : abs(JetGood_hadronFlavour[0]) != 4 && abs(JetGood_hadronFlavour[0]) != 5; FillColor=ROOT.kGray+0,  Label="W+j\, other" #, NormSystematic=0.5
+
+TT : TTJets   : xsec : 1 ; FillColor=ROOT.kGreen+1, Label="tt"
+
+DY : DYJetsToLL_M10to50 : xsec : 1 ; FillColor=ROOT.kGray+2, Label="Z+jets" #, NormSystematic=0.5
+DY : DYJetsToLL_M50     : xsec : 1 ; FillColor=ROOT.kGray+2, Label="Z+jets" #, NormSystematic=0.5
+
+QCD : QCD_Mu15 : xsec : 1 ; FillColor=ROOT.kOrange-3, Label="QCD"
+
+#data : SingleElectron_Run2016G_23Sep2016_part0 + SingleElectron_Run2016G_23Sep2016_part1 + SingleElectron_Run2016G_23Sep2016_part2 + SingleElectron_Run2016G_23Sep2016_part3 + SingleElectron_Run2016G_23Sep2016_part4 + SingleElectron_Run2016G_23Sep2016_part5
+#data : SingleElectron_Run2016H_PromptReco_v2_part0 + SingleElectron_Run2016H_PromptReco_v2_part1 + SingleElectron_Run2016H_PromptReco_v2_part2 + SingleElectron_Run2016H_PromptReco_v2_part3 + SingleElectron_Run2016H_PromptReco_v2_part4
+data : SingleMuon_Run2016G_23Sep2016_part1 + SingleMuon_Run2016G_23Sep2016_part2 + SingleMuon_Run2016G_23Sep2016_part3 + SingleMuon_Run2016G_23Sep2016_part4 + SingleMuon_Run2016G_23Sep2016_part5 + SingleMuon_Run2016G_23Sep2016_part6 + SingleMuon_Run2016G_23Sep2016_part7 + SingleMuon_Run2016G_23Sep2016_part8 + SingleMuon_Run2016G_23Sep2016_part9 + SingleMuon_Run2016G_23Sep2016_part10
+#data : SingleMuon_Run2016H_PromptReco_v2_part0 + SingleMuon_Run2016H_PromptReco_v2_part1 + SingleMuon_Run2016H_PromptReco_v2_part2 + SingleMuon_Run2016H_PromptReco_v2_part3 + SingleMuon_Run2016H_PromptReco_v2_part4 + SingleMuon_Run2016H_PromptReco_v2_part5 + SingleMuon_Run2016H_PromptReco_v2_part6 + SingleMuon_Run2016H_PromptReco_v2_part7 + SingleMuon_Run2016H_PromptReco_v2_part8 + SingleMuon_Run2016H_PromptReco_v2_part9

--- a/TTHAnalysis/python/plotter/susy-stopSoftB/plots-CR2L.txt
+++ b/TTHAnalysis/python/plotter/susy-stopSoftB/plots-CR2L.txt
@@ -1,4 +1,6 @@
+# vim: syntax=sh
 yield: 0.5 : 1,0,1; XTitle="Events", MoreY=2
+dilep OS   : nLepGood >= 2 && LepGood1_charge * LepGood2_charge < 0
 ### LEPTONS
 lep1Pt:  LepGood1_pt       : 30,0,150; XTitle="Leading lepton p_{T} [GeV]"
 lep1Eta: abs(LepGood1_eta) : 6,0,2.5; XTitle="Leading lepton |#eta|"
@@ -11,7 +13,7 @@ worstMVA: min(LepGood1_mvaTTH,LepGood2_mvaTTH) : 20,0,1; XTitle="Worst MVA", Leg
 met:  met: 15,0,300 ; XTitle="E_{T}^{miss}  [GeV]"
 mtW1: mt_2(LepGood1_pt,LepGood1_phi,met,met_phi) : 18,0,240; XTitle="M_{T}(l_{1}\,E_{T}^{miss}) [GeV]", Legend='TL'
 mtW2: mt_2(LepGood2_pt,LepGood2_phi,met,met_phi) : 18,0,240; XTitle="M_{T}(l_{2}\,E_{T}^{miss}) [GeV]"
-mtWmin: min(mt_2(LepGood1_pt,LepGood1_phi,met,met_phi),mt_2(LepGood2_pt,LepGood2_phi,met,met_phi)) : 18,0,240; XTitle="min M_{T}(l_{i}\,E_{T}^{miss}) [GeV]", Legend='TR'
+mtWmin: min(mt_2(LepGood1_pt,LepGood1_phi,met,met_phi),mt_2(LepGood2_pt,LepGood2_phi,met,met_phi)) : 18,0,180; XTitle="min M_{T}(l_{i}\,E_{T}^{miss}) [GeV]", Legend='TR'
 mtWmax: max(mt_2(LepGood1_pt,LepGood1_phi,met,met_phi),mt_2(LepGood2_pt,LepGood2_phi,met,met_phi)) : 18,0,240; XTitle="max M_{T}(l_{i}\,E_{T}^{miss}) [GeV]", Legend='TL'
 minProjMet: met_pt*min(if3(cos(met_phi-LepGood1_phi)>0, abs(sin(met_phi-LepGood1_phi)), 1), \
                        if3(cos(met_phi-LepGood2_phi)>0, abs(sin(met_phi-LepGood2_phi)), 1) ) : 20,0,200; XTitle="Min Proj E_{T}^{miss}  [GeV]"
@@ -20,9 +22,9 @@ dphiLLmet : abs(deltaPhi(phi_2(LepGood1_pt,LepGood1_phi,LepGood2_pt,LepGood2_phi
 nLepGood  : nLepGood  : [1.5,2.5,3.5,4.5]  ; XTitle='N(lep\, tight)', XNDiv=505
 nLepOther : nLepOther : [-0.5,0.5,1.5,2.5] ; XTitle='N(lep\, fail)', XNDiv=505
 
-nSoftMu       : Sum$(LepOtherGood_pt < 25 && LepOtherGood_mediumMuonId > 0)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(soft mu)', XNDiv=505, Logy
-nSoftMuSip6   : Sum$(LepOtherGood_sip3d > 6 && LepOtherGood_pt < 25 && LepOtherGood_mediumMuonId > 0)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(soft mu)', XNDiv=505, Logy
-nSoftMuSip6AI : Sum$(LepOtherGood_sip3d > 6 && LepOtherGood_miniRelIso > 0.4 && LepOtherGood_pt < 25 && LepOtherGood_mediumMuonId > 0)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(soft mu)', XNDiv=505, Logy
+nSoftMu         : Sum$(LepOtherGood_pt < 20)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(soft mu)', XNDiv=505, Logy
+nSoftMuJV       : Sum$(deltaR(LepOtherGood_eta,LepOtherGood_phi,Jet_eta[iJetGood[0]],Jet_phi[iJetGood[0]]) > 0.4 && LepOtherGood_pt < 20)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(soft mu)', XNDiv=505, Logy
+nSoftMuJVSip3AI : Sum$(deltaR(LepOtherGood_eta,LepOtherGood_phi,Jet_eta[iJetGood[0]],Jet_phi[iJetGood[0]]) > 0.4 && LepOtherGood_sip3d > 3 && LepOtherGood_miniRelIso > 0.2 && LepOtherGood_pt < 20)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(soft mu)', XNDiv=505, Logy
 nSoftIVF_pt40 : Sum$(abs(SV_dxy)<2 && SV_cosTheta > 0.98 && SV_ntracks >= 3 && SV_sip3d > 4 && SV_jetPt < 40)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(IVF\, p_{T}(j) < 40)', XNDiv=505, Logy
 nSoftIVF_pt20 : Sum$(abs(SV_dxy)<2 && SV_cosTheta > 0.98 && SV_ntracks >= 3 && SV_sip3d > 4 && SV_jetPt < 20)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(IVF\, p_{T}(j) < 20)', XNDiv=505, Logy
 nSoftIVF_pt40b20 : Sum$(abs(SV_dxy)<2 && SV_cosTheta > 0.98 && SV_ntracks >= 3 && SV_sip3d > 4 && (SV_jetPt < 20 || SV_jetPt < 40 && SV_jetBTagCSV < 0.46) )  : [-0.5,0.5,1.5,2.5] ; XTitle='N(IVF\, p_{T}(j) < 40/20)', XNDiv=505, Logy
@@ -96,15 +98,15 @@ SV_jetPt: SV_jetPt : [0,20,30,40]; XTitle="SV p_{T}(jet)", MoreY=1.5, Legend="TL
 LepOtherGood_pt    : LepOtherGood_pt[0] : [0,3,4,5,6,7,8,10,12,14,17,20]; XTitle="Soft muon p_{T}", Density=True, YTitle="Events / GeV", LegendCutoff=0.001, IncludeOverflows=True
 LepOtherGood_pt_zoom : LepOtherGood_pt[0] : 12,0,18; XTitle="Soft muon p_{T}", LegendCutoff=0.001, IncludeOverflows=True
 LepOtherGood_eta : abs(LepOtherGood_eta[0]) : 8,0,2.4; XTitle="Soft muon |eta|"
-LepOtherGood_dxy : abs(LepOtherGood_dxy[0]) : 10,0,0.15; XTitle="Soft muon |dxy|"
-LepOtherGood_dz : abs(LepOtherGood_dz[0]) : 10,0,0.2; XTitle="Soft muon |dz|"
+LepOtherGood_dxy : abs(LepOther_dxy[iLepOtherGood[0]]) : 10,0,0.15; XTitle="Soft muon |dxy|"
+LepOtherGood_dz : abs(LepOther_dz[iLepOtherGood[0]]) : 10,0,0.2; XTitle="Soft muon |dz|"
 LepOtherGood_sip3d : LepOtherGood_sip3d[0] : 18,0,24; XTitle="Soft muon sip3d", LegendCutoff=0.001
 LepOtherGood_drLep : min(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],LepGood1_eta,LepGood1_phi),deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],LepGood2_eta,LepGood2_phi)) : 10,0,4; XTitle="Soft muon #DeltaR(l)", MoreY=1.5
-LepOtherGood_drJet : min(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta,JetGood_phi),Alt$(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[1],JetGood_phi[1]),999)) : 20,0,4; XTitle="Soft muon #DeltaR(j_{i})", MoreY=1.5
+LepOtherGood_drJet : min(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[0],JetGood_phi[0]),Alt$(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[1],JetGood_phi[1]),999)) : 20,0,4; XTitle="Soft muon #DeltaR(j_{i})", MoreY=1.5
 LepOtherGood_miniRelIso : LepOtherGood_miniRelIso[0] : [0,0.2,0.3,0.5,0.7,1.0,1.5,2.0,3.0]; XTitle="Soft muon miniRelIso", Density=True, YTitle="Events / bin width", LegendCutoff=0.001
 LepOtherGood_mediumMuonId : LepOtherGood_mediumMuonId[0] : [-0.5,0.5,1.5]; XTitle="LepOtherGood mediumMuonId", Legend="TL", LegendCutoff=0.001
-#LepOtherGood_drJet1 : deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[0],JetGood_phi[0]) : 10,0,4; XTitle="Soft muon #DeltaR(j_{1})", MoreY=1.5
-#LepOtherGood_drJet2 : Alt$(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[1],JetGood_phi[1]),999) : 10,0,4; XTitle="Soft muon #DeltaR(j_{1})", MoreY=1.5, IncludeOverflows=False
+LepOtherGood_drJet1 : deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[0],JetGood_phi[0]) : 10,0,4; XTitle="Soft muon #DeltaR(j_{1})", MoreY=1.5
+LepOtherGood_drJet2 : Alt$(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[1],JetGood_phi[1]),999) : 10,0,4; XTitle="Soft muon #DeltaR(j_{1})", MoreY=1.5, IncludeOverflows=False
 #LepOtherGood_relIso03 : LepOtherGood_relIso03[0] : [0,0.1,0.2,0.3,0.4,0.6,0.8,1.0,1.5,2.0,2.5,3.0,4.0]; XTitle="Soft muon relIso03", Density=True, YTitle="Events / bin width", LegendCutoff=0.001
 #LepOtherGood_trackHighPurityMuon : LepOtherGood_trackHighPurityMuon[0] : [-0.5,0.5,1.5]; XTitle="Soft muon trackHighPurityMuon", Legend="TL"
 #LepOtherGood_nStations : LepOtherGood_nStations : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5]; XTitle="LepOtherGood nStations"

--- a/TTHAnalysis/python/plotter/susy-stopSoftB/plots-CRWc.txt
+++ b/TTHAnalysis/python/plotter/susy-stopSoftB/plots-CRWc.txt
@@ -1,0 +1,120 @@
+# vim: syntax=sh
+
+yield: 0.5 : 1,0,1; XTitle="Events", MoreY=2
+### LEPTONS
+lep1Pt:  LepGood1_pt       : 60,0,150; XTitle="lepton p_{T} [GeV]"
+lep1Eta: abs(LepGood1_eta) : 14,0,2.8; XTitle="lepton |#eta|"
+#lep1IsoM: LepGood1_miniRelIso : 20,0,0.2; XTitle="lepton miniRelIso", XNDiv=505
+#lep1Iso03: LepGood1_relIso03  : 20,0,0.5; XTitle="lepton relIso04", XNDiv=505
+#lep1Sip: LepGood1_sip3d : 20,0,8; XTitle="lepton sip3d"
+#lep1MVA: LepGood1_mvaTTH: 20,0,1; XTitle="lepton MVA", Legend="TL"
+
+met:  met: 60,0,200 ; XTitle="E_{T}^{miss}  [GeV]"
+mtW: mt_2(LepGood1_pt,LepGood1_phi,met,met_phi) : 72,0,180; XTitle="M_{T}(l_{1}\,E_{T}^{miss}) [GeV]", Legend='TL'
+
+#nLepGood  : nLepGood  : [0.5,1.5,2.5,3.5,4.5]  ; XTitle='N(lep\, tight)', XNDiv=505
+nLepOther : nLepOther : [-0.5,0.5,1.5,2.5] ; XTitle='N(lep\, fail)', XNDiv=505
+
+#nSoftMu       : Sum$(LepOtherGood_pt < 25 && LepOtherGood_mediumMuonId > 0)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(soft mu)', XNDiv=505, Logy
+#nSoftMuSip6   : Sum$(LepOtherGood_sip3d > 6 && LepOtherGood_pt < 25 && LepOtherGood_mediumMuonId > 0)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(soft mu)', XNDiv=505, Logy
+#nSoftMuSip6AI : Sum$(LepOtherGood_sip3d > 6 && LepOtherGood_miniRelIso > 0.4 && LepOtherGood_pt < 25 && LepOtherGood_mediumMuonId > 0)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(soft mu)', XNDiv=505, Logy
+nSoftIVF_pt40 : Sum$(abs(SV_dxy)<2 && SV_cosTheta > 0.98 && SV_ntracks >= 3 && SV_sip3d > 4 && SV_jetPt < 40)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(IVF\, p_{T}(j) < 40)', XNDiv=505, Logy
+nSoftIVF_pt20 : Sum$(abs(SV_dxy)<2 && SV_cosTheta > 0.98 && SV_ntracks >= 3 && SV_sip3d > 4 && SV_jetPt < 20)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(IVF\, p_{T}(j) < 20)', XNDiv=505, Logy
+nSoftIVF_pt40b20 : Sum$(abs(SV_dxy)<2 && SV_cosTheta > 0.98 && SV_ntracks >= 3 && SV_sip3d > 4 && (SV_jetPt < 20 || SV_jetPt < 40 && SV_jetBTagCSV < 0.46) )  : [-0.5,0.5,1.5,2.5] ; XTitle='N(IVF\, p_{T}(j) < 40/20)', XNDiv=505, Logy
+
+
+### DILEPTONS
+#mll  : mass_2(LepGood1_pt,LepGood1_eta,LepGood1_phi,LepGood1_mass,LepGood2_pt,LepGood2_eta,LepGood2_phi,LepGood2_mass): 15,0,300; XTitle="m(ll) [GeV]"
+#ptll : pt_2(LepGood1_pt,LepGood1_phi,LepGood2_pt,LepGood2_phi): 30,0,150; XTitle="p_{T}(ll) [GeV]", XNDiv=505
+#htll : LepGood1_pt+LepGood2_pt: 15,0,300; XTitle="H_{T}(ll) [GeV]"
+#drll : deltaR(LepGood1_eta,LepGood1_phi, LepGood2_eta,LepGood2_phi): 8,0,4; XTitle="#DeltaR(ll)", MoreY=1.3, Legend='TR'
+#dphill : abs(deltaPhi(LepGood1_phi, LepGood2_phi)): 6,0,3.1416; XTitle="#Delta#phi(ll)", MoreY=1.5, Legend='TR'
+
+### JETS
+nJet20 : Sum$(JetGood_pt > 20)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 20)'
+nJet30 : Sum$(JetGood_pt > 30)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 30)'
+nJet40 : Sum$(JetGood_pt > 40)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 40)'
+
+nJet20CSVL : Sum$(JetGood_pt > 20 && JetGood_btagCSV > 0.46)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 20\, CSVL)'
+nJet30CSVL : Sum$(JetGood_pt > 30 && JetGood_btagCSV > 0.46)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 30\, CSVL)'
+nJet40CSVL : Sum$(JetGood_pt > 40 && JetGood_btagCSV > 0.46)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 40\, CSVL)'
+
+nJet20CSVM : Sum$(JetGood_pt > 20 && JetGood_btagCSV > 0.80)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 20\, CSVM)'
+nJet30CSVM : Sum$(JetGood_pt > 30 && JetGood_btagCSV > 0.80)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 30\, CSVM)'
+nJet40CSVM : Sum$(JetGood_pt > 40 && JetGood_btagCSV > 0.80)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 40\, CSVM)'
+
+nJetFwd30 : Sum$(JetFwd_pt > 30)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 30\, |#eta|>2.4)'
+nJetFwd40 : Sum$(JetFwd_pt > 40)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 40\, |#eta|>2.4)'
+
+#nJet20CSVL_fit: Sum$(JetGood_pt > 20 && JetGood_btagCSV > 0.46)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(jet\, p_{T} > 20\, CSVL)'
+#nJet30CSVL_fit: Sum$(JetGood_pt > 30 && JetGood_btagCSV > 0.46)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(jet\, p_{T} > 30\, CSVL)'
+#nJet40CSVL_fit: Sum$(JetGood_pt > 40 && JetGood_btagCSV > 0.46)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(jet\, p_{T} > 40\, CSVL)'
+#nJet20CSVM_fit: Sum$(JetGood_pt > 20 && JetGood_btagCSV > 0.80)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(jet\, p_{T} > 20\, CSVM)'
+#nJet30CSVM_fit: Sum$(JetGood_pt > 30 && JetGood_btagCSV > 0.80)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(jet\, p_{T} > 30\, CSVM)'
+#nJet40CSVM_fit: Sum$(JetGood_pt > 40 && JetGood_btagCSV > 0.80)  : [-0.5,0.5,1.5,2.5] ; XTitle='N(jet\, p_{T} > 40\, CSVM)'
+# nJet20 : nJet               : [0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 20)'
+# nJet40 : Sum$(JetGood_pt > 40)  : [0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 40)'
+# nJet30Fwd : Sum$(JetFwd_pt > 30)  : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5] ; XTitle='N(jet\, p_{T} > 30\, |#eta| > 2.4)'
+# nBJetsLoose20 : nBJetsLoose20 : [0.5,1.5,2.5,3.5,4.5] ; XTitle='N(jet\, p_{T} > 20\, CSV Loose)', XNDiv=505
+# nBJetsMedium20 : nBJetsMedium20 : [-0.5,0.5,1.5,2.5,3.5,4.5] ; XTitle='N(jet\, p_{T} > 20\, CSV Medium)', XNDiv=505
+# nBJetsLoose40 : nBJetsLoose40 : [0.5,1.5,2.5,3.5,4.5] ; XTitle='N(jet\, p_{T} > 40\, CSV Loose)', XNDiv=505
+# nBJetsMedium40 : nBJetsMedium40 : [-0.5,0.5,1.5,2.5,3.5,4.5] ; XTitle='N(jet\, p_{T} > 40\, CSV Medium)', XNDiv=505
+#tagJetPt: JetGood_pt: 25,0,250; XTitle="tag jet p_{T} [GeV]", Legend='TR'
+#tagJetBTag: JetGood_btagCSV: 15,0,1; XTitle="tag jet btag", Legend='TL'
+# #jetPt2: Jet2_pt: 20,0,100; XTitle="2nd jet p_{T} [GeV]", Legend='TL'
+# jetBTag2: Jet2_btagCSV: 15,0,1; XTitle="2nd jet btag", Legend='TR'
+# jetPt2_zoom: Alt$(JetGood_pt[1],0): [0,20,25,30,35,40]; XTitle="2nd jet p_{T} [GeV]", Legend='TL'
+# jetBTagMax: max(Jet1_btagCSV,Jet2_btagCSV): 15,0,1; XTitle="max btag (j_{1}\,j_{2})", Legend='TR'
+
+leadJetPt: JetGood_pt[0]: 25,0,250; XTitle="lead jet p_{T} [GeV]", Legend='TR'
+leadJetBTag: JetGood_btagCSV[0]: 20,0.0,1.0; XTitle="lead b-tag CSV", Legend='TL', XNDiv=505, MoreY=1.4
+leadJetCTagVsB: Jet_ctagCsvB[iJetGood[0]]: 20,-1.0,1.0; XTitle="lead c-tag vs b", Legend='TR', XNDiv=505, MoreY=1.4
+leadJetCTagVsL: Jet_ctagCsvL[iJetGood[0]]: 14,-0.7,1.0; XTitle="lead c-tag vs light", Legend='TL', XNDiv=505, MoreY=1.4
+#trailJetPt: Alt$(JetGood_pt[1],0): 25,0,125; XTitle="trail jet p_{T} [GeV]", Legend='TR'
+#trailJetPt_zoom: Alt$(JetGood_pt[1],0): 8,20,40; XTitle="trail jet p_{T} [GeV]", Legend='TR', IncludeOverflows=False
+
+SV_pt : SV_pt : 30,0,60; XTitle="SV p_{T}"
+SV_pt_zoom : SV_pt : 40,0,20; XTitle="SV p_{T}", IncludeOverflows=False, YTitle="Entries"
+SV_mass : SV_mass : 30,0,5; XTitle="SV mass [GeV]", YTitle="Entries"
+SV_eta : abs(SV_eta) : 8,0,2.4; XTitle="SV |eta|", YTitle="Entries", MoreY=1.6
+SV_ntracks : SV_ntracks : [0.5,1.5,2.5,3.5,4.5,5.5,6.5,7.5,8.5,9.5,10.5]; XTitle="N(trk)", YTitle="Entries"
+SV_c2n: SV_chi2/SV_ndof : 24,0,5; XTitle="SV normalized #chi^{2}", YTitle="Entries"
+SV_sip2d: abs(SV_dxy/SV_edxy) : 24,0,40; XTitle="S_{IP2D}", YTitle="Entries"
+SV_sip2d_zoom: abs(SV_dxy/SV_edxy) : 20,0,10; XTitle="S_{IP2D}", Legend="TL", IncludeOverflows=False, YTitle="Entries"
+SV_sip3d: SV_sip3d : 20,0,40; XTitle="S_{IP3D}", YTitle="Entries"
+SV_sip3d_zoom: SV_sip3d : 20,0,10; XTitle="S_{IP3D}", Legend="TL", IncludeOverflows=False, YTitle="Entries"
+SV_ip2d: abs(SV_dxy) : 24,0,1.2; XTitle="IP_{2D} [cm]", YTitle="Entries"
+SV_ip2d_log: abs(SV_dxy) : 24,0,2.4; XTitle="IP_{2D} [cm]", Logy, YTitle="Entries"
+SV_ip3d: SV_ip3d : 24,0,1.2; XTitle="IP_{3D} [cm]", YTitle="Entries"
+SV_ip3d_log: SV_ip3d : 24,0,2.4; XTitle="IP_{3D} [cm]", Logy, YTitle="Entries"
+SV_theta: acos(SV_cosTheta): 24,0,0.24; XTitle="p-r angle [rad]", XNDiv=505, YTitle="Entries"
+SV_omcosTheta: 1-SV_cosTheta: 24,0,0.02; XTitle="1-cos(p-r) angle", XNDiv=505, YTitle="Entries"
+#SV_mva: SV_mva: 20, 0.8, 1; XTitle="SV mva", Legend="TL", XNDiv=505, YTitle="Entries"
+SV_jetPt: SV_jetPt : [0,20,25,30,35,40,45,50,60,70,80,100]; XTitle="SV p_{T}(jet)", MoreY=1.5, Legend="TR", Density=True, YTitle="Entries / GeV"
+
+SV_w_dphi : abs(deltaPhi(phi_2(LepGood1_pt,LepGood1_phi,met_pt,met_phi),SV_phi))  : 20,0,3.1416; XTitle="#Delta#phi(SV\,W)", YTitle="Entries", Legend='TL', MoreY=1.2
+SV_l_dphi : abs(deltaPhi(LepGood1_phi,SV_phi))  : 20,0,3.1416; XTitle="#Delta#phi(SV\,l)", YTitle="Entries", Legend='TL', MoreY=1.2
+SV_v_dphi : abs(deltaPhi(met_phi,SV_phi))  : 20,0,3.1416; XTitle="#Delta#phi(SV\,E_{T}^{miss})", YTitle="Entries", Legend='TL', MoreY=1.2
+
+SV_mDKpp : m_D_Kpp(SV_tk1_pt*SV_tk1_charge, SV_tk1_eta, \
+                   SV_tk2_pt*SV_tk2_charge, SV_tk2_eta, SV_tk2_phi - SV_tk1_phi, \
+                   SV_tk3_pt*SV_tk3_charge, SV_tk3_eta, SV_tk3_phi - SV_tk1_phi) : 40,1,3 ; XTitle="M(K#pi#pi)  (GeV)", Legend="TR", IncludeOverflows=False, YTitle="Entries"
+SV_mDKpp_zoom : m_D_Kpp(SV_tk1_pt*SV_tk1_charge, SV_tk1_eta, \
+                   SV_tk2_pt*SV_tk2_charge, SV_tk2_eta, SV_tk2_phi - SV_tk1_phi, \
+                   SV_tk3_pt*SV_tk3_charge, SV_tk3_eta, SV_tk3_phi - SV_tk1_phi) : 40,1.6,2.2 ; XTitle="M(K#pi#pi)  (GeV)", Legend="TR", IncludeOverflows=False, YTitle="Entries"
+#LepOtherGood_pt      : LepOtherGood_pt[0] : 15,0,30; XTitle="Soft muon p_{T}", IncludeOverflows=True
+#LepOtherGood_pt    : LepOtherGood_pt[0] : [0,3,4,5,6,7,8,10,12,14,17,20]; XTitle="Soft muon p_{T}", Density=True, YTitle="Events / GeV", LegendCutoff=0.001, IncludeOverflows=True
+#LepOtherGood_pt_zoom : LepOtherGood_pt[0] : 12,0,18; XTitle="Soft muon p_{T}", LegendCutoff=0.001, IncludeOverflows=True
+#LepOtherGood_eta : abs(LepOtherGood_eta[0]) : 8,0,2.4; XTitle="Soft muon |eta|"
+#LepOtherGood_dxy : abs(LepOtherGood_dxy[0]) : 10,0,0.15; XTitle="Soft muon |dxy|"
+#LepOtherGood_dz : abs(LepOtherGood_dz[0]) : 10,0,0.2; XTitle="Soft muon |dz|"
+#LepOtherGood_sip3d : LepOtherGood_sip3d[0] : 18,0,24; XTitle="Soft muon sip3d", LegendCutoff=0.001
+#LepOtherGood_drLep : min(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],LepGood1_eta,LepGood1_phi),deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],LepGood2_eta,LepGood2_phi)) : 10,0,4; XTitle="Soft muon #DeltaR(l)", MoreY=1.5
+#LepOtherGood_drJet : min(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta,JetGood_phi),Alt$(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[1],JetGood_phi[1]),999)) : 20,0,4; XTitle="Soft muon #DeltaR(j_{i})", MoreY=1.5
+#LepOtherGood_miniRelIso : LepOtherGood_miniRelIso[0] : [0,0.2,0.3,0.5,0.7,1.0,1.5,2.0,3.0]; XTitle="Soft muon miniRelIso", Density=True, YTitle="Events / bin width", LegendCutoff=0.001
+#LepOtherGood_mediumMuonId : LepOtherGood_mediumMuonId[0] : [-0.5,0.5,1.5]; XTitle="LepOtherGood mediumMuonId", Legend="TL", LegendCutoff=0.001
+#LepOtherGood_drJet1 : deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[0],JetGood_phi[0]) : 10,0,4; XTitle="Soft muon #DeltaR(j_{1})", MoreY=1.5
+#LepOtherGood_drJet2 : Alt$(deltaR(LepOtherGood_eta[0],LepOtherGood_phi[0],JetGood_eta[1],JetGood_phi[1]),999) : 10,0,4; XTitle="Soft muon #DeltaR(j_{1})", MoreY=1.5, IncludeOverflows=False
+#LepOtherGood_relIso03 : LepOtherGood_relIso03[0] : [0,0.1,0.2,0.3,0.4,0.6,0.8,1.0,1.5,2.0,2.5,3.0,4.0]; XTitle="Soft muon relIso03", Density=True, YTitle="Events / bin width", LegendCutoff=0.001
+#LepOtherGood_trackHighPurityMuon : LepOtherGood_trackHighPurityMuon[0] : [-0.5,0.5,1.5]; XTitle="Soft muon trackHighPurityMuon", Legend="TL"
+#LepOtherGood_nStations : LepOtherGood_nStations : [-0.5,0.5,1.5,2.5,3.5,4.5,5.5]; XTitle="LepOtherGood nStations"

--- a/TTHAnalysis/python/tools/susyStopSoftBReCleaner.py
+++ b/TTHAnalysis/python/tools/susyStopSoftBReCleaner.py
@@ -1,0 +1,92 @@
+from CMGTools.TTHAnalysis.treeReAnalyzer import Collection, deltaR
+from CMGTools.TTHAnalysis.tools.collectionSkimmer import CollectionSkimmer
+import ROOT, os
+
+class JetReCleaner:
+    def __init__(self,label=""):
+        self.label = "" if (label in ["",None]) else ("_"+label)
+        self.floats = ("pt","eta","phi","btagCSV")
+        self.ints = ("hadronFlavour",)
+        if "/jetReCleanerExampleHelper_cxx.so" not in ROOT.gSystem.GetLibraries():
+            ROOT.gROOT.ProcessLine(".L %s/src/CMGTools/TTHAnalysis/python/tools/jetReCleanerExampleHelper.cxx+" % os.environ['CMSSW_BASE'])
+    def init(self,tree):
+        for v in self.floats+self.ints:
+            if not tree.GetBranch("Jet_"+v): print "Missing branch Jet_"+v
+        self.floats = [v for v in self.floats if tree.GetBranch("Jet_"+v)]
+        self.ints   = [v for v in self.ints   if tree.GetBranch("Jet_"+v)]
+        self._helper = CollectionSkimmer("JetGood"+self.label, "Jet", floats=self.floats, ints=self.ints, saveSelectedIndices=True, maxSize=20)
+        self._worker = ROOT.JetReCleanerExampleHelper(self._helper.cppImpl())
+        self._helper.initInputTree(tree)
+        self.initReaders(tree)
+        self._helper.initOutputTree(self._out);
+    def listBranches(self):
+        return []
+    def initReaders(self,tree):
+        for B in "nLepGood", "nJet": setattr(self, B, tree.valueReader(B))
+        for B in "eta", "phi" : setattr(self,"LepGood_"+B, tree.arrayReader("LepGood_"+B))
+        for B in "eta", "phi" : setattr(self,"Jet_"+B, tree.arrayReader("Jet_"+B))
+        self._worker.setLeptons(self.nLepGood, self.LepGood_eta, self.LepGood_phi)
+        self._worker.setJets(self.nJet, self.Jet_eta, self.Jet_phi)
+    def setOutputTree(self,pytree):
+        self._out = pytree
+    def __call__(self,event):
+        ## Init
+        if self._helper.initEvent(event):
+            self.initReaders(event._tree)
+        ## Algo
+        self._worker.run()
+        return {}
+
+class LepOtherCleaner:
+    def __init__(self,label=""):
+        self.label = "" if (label in ["",None]) else ("_"+label)
+        self.floats = ("pt","eta","phi","miniRelIso","sip3d")
+        self.ints = ("mcMatchAny","mcMatchId","mediumMuonId",)
+    def init(self,tree):
+        for v in self.floats+self.ints:
+            if not tree.GetBranch("LepOther_"+v): print "Missing branch LepOther_"+v
+        self.floats = [v for v in self.floats if tree.GetBranch("LepOther_"+v)]
+        self.ints   = [v for v in self.ints   if tree.GetBranch("LepOther_"+v)]
+        self._helper = CollectionSkimmer("LepOtherGood"+self.label, "LepOther", floats=self.floats, ints=self.ints, saveSelectedIndices=True, maxSize=20)
+        self._helper.initInputTree(tree)
+        self.initReaders(tree)
+        self._helper.initOutputTree(self._out);
+    def listBranches(self):
+        return []
+    def initReaders(self,tree):
+        for B in "nLepGood", "nLepOther", "nJet": setattr(self, B, tree.valueReader(B))
+        for B in "eta", "phi" : setattr(self,"LepGood_"+B, tree.arrayReader("LepGood_"+B))
+        for B in "pt", "eta", "phi", "btagCSV" : setattr(self,"Jet_"+B, tree.arrayReader("Jet_"+B))
+        for B in "eta", "phi","pdgId", "dz": setattr(self,"LepOther_"+B, tree.arrayReader("LepOther_"+B))
+    def setOutputTree(self,pytree):
+        self._out = pytree
+    def __call__(self,event):
+        ## Init
+        if self._helper.initEvent(event):
+            self.initReaders(event._tree)
+        ## Algo
+        vetos = [ (self.LepGood_eta[i],self.LepGood_phi[i]) for i in xrange(self.nLepGood.Get()[0]) ]
+        for i in xrange(self.nJet.Get()[0]):
+            jeta,jphi = (self.Jet_eta[i],self.Jet_phi[i])
+            if min(deltaR(jeta,jphi,leta,lphi) for (leta,lphi) in vetos) > 0.4:
+                vetos.append((jeta,jphi)) 
+                break ## clean respect to the leading jet only
+        #vetos += [ (self.Jet_eta[i],self.Jet_phi[i]) for i in ijets if self.Jet_pt[i] > 40 or self.Jet_btagCSV[i] > 0.46 ]
+        for i in xrange(self.nLepOther.Get()[0]):
+            if abs(self.LepOther_pdgId[i]) != 13: continue
+            if abs(self.LepOther_dz[i]) >= 0.2: continue
+            eta, phi = self.LepOther_eta[i], self.LepOther_phi[i]
+            bad = False
+            for (le,lp) in vetos:
+                if abs(le-eta) < 0.4 and deltaR(le,lp,eta,phi) < 0.4:
+                    bad = True; 
+                    break
+            if not bad: self._helper.push_back(i)
+        return {}
+
+MODULES = [
+    ('jets', lambda : JetReCleaner()),
+    ('leps', lambda : LepOtherCleaner()),
+]
+
+

--- a/TTHAnalysis/python/tools/treeReaderArrayTools.py
+++ b/TTHAnalysis/python/tools/treeReaderArrayTools.py
@@ -57,7 +57,7 @@ def readBranch(tree, branchName):
 
 ####### PRIVATE IMPLEMENTATION PART #######
 
-_rootType2Python = { 'Int_t':int, 'Long_t':long, 'UInt_t':int, 'ULong_t':long,
+_rootType2Python = { 'Int_t':int, 'Long_t':long, 'UInt_t':int, 'ULong_t':long, 'ULong64_t':"unsigned long long",
                      'Float_t':float, 'Double_t':float }
 
 def _makeArrayReader(tree, typ, nam, remakeAllFirst=True):


### PR DESCRIPTION
* Minor fix to treeReaderArrayTools (used by treeReAnalyzer2 or prepareEventVariablesFriendTree.py with `--tra2`) to allow accessing `ULong64_t` variables like the event number.
* Fix skimTrees (was broken)
* Implement correctly --max-size when not on cernbox fs (thanks @peruzzim for noticing)
* in `mcPlots.py`, in the legend draw the signal as a line when it's not stacked.

The rest is all stuff for the soft-b stop search.