### PR TITLE
Updated calls to Spring16 electron ID MVA

### DIFF
--- a/HToZZ4L/python/analyzers/zzTypes.py
+++ b/HToZZ4L/python/analyzers/zzTypes.py
@@ -3,7 +3,7 @@ from PhysicsTools.Heppy.analyzers.core.AutoFillTreeProducer  import *
 leptonTypeHZZ = NTupleObjectType("leptonHZZ", baseObjectTypes = [ leptonTypeExtra ], variables = [
     NTupleVariable("looseId",     lambda x : x.looseIdSusy, int, help="Loose HZZ ID"),
     NTupleVariable("mvaIdSpring15",   lambda lepton : lepton.mvaRun2("NonTrigSpring15MiniAOD") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID for non-triggering electrons, Spring15 re-training; 1 for muons"),
-    NTupleVariable("mvaIdSpring16",   lambda lepton : lepton.mvaRun2("Spring16") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID, Spring16 training; 1 for muons"),
+    NTupleVariable("mvaIdSpring16",   lambda lepton : lepton.mvaRun2("Spring16HZZ") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID, Spring16 training; 1 for muons"),
     # ----------------------
     # Extra isolation variables
     NTupleVariable("relIsoAfterFSR",    lambda x : x.relIsoAfterFSR,   help="RelIso after FSR"),

--- a/ObjectStudies/python/analyzers/treeProducerLepTnP.py
+++ b/ObjectStudies/python/analyzers/treeProducerLepTnP.py
@@ -5,7 +5,7 @@ from CMGTools.ObjectStudies.analyzers.leptonTriggerMatching_cff import WithLepto
 leptonTypeTnP = NTupleObjectType("leptonTnP", baseObjectTypes = [ leptonType, WithLeptonTriggerMatchType ], variables = [
     NTupleVariable("looseId",     lambda x : x.looseIdSusy, int, help="Loose ID (as per lepton analyzer)"),
     NTupleVariable("mvaIdSpring15",   lambda lepton : lepton.mvaRun2("NonTrigSpring15MiniAOD") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID for non-triggering electrons, Spring15 re-training; 1 for muons"),
-    NTupleVariable("mvaIdSpring16",   lambda lepton : lepton.mvaRun2("Spring16") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID, Spring16; 1 for muons"),
+    NTupleVariable("mvaIdSpring16",   lambda lepton : lepton.mvaRun2("Spring16HZZ") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID, Spring16; 1 for muons"),
     # ----------------------
     NTupleVariable("eleMVASpring15_VLooseIdEmu", lambda x : x.electronID("POG_MVA_ID_Spring15_NonTrig_VLooseIdEmu") if abs(x.pdgId())==11 else 1, int, help="VLoose MVA Ele ID (as per susy)"),
     NTupleVariable("eleMVASpring15_HZZ",         lambda x : x.electronID("MVA_ID_NonTrig_Spring15_HZZ")             if abs(x.pdgId())==11 else 1, int, help="MVA Ele ID (as per hzz)"),

--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ cd $CMSSW_BASE/src
 scram b -j 8
 ```
 
-#### Throubleshooting
+followed by the import of the Spring16 electron MVA ID weights:
 
-If you encounter problems at runtime related
-to the Spring16 electron ID MVA, please see [this](https://github.com/CERN-PH-CMG/cmg-cmssw/pull/661).
+```
+cd $CMSSW_BASE/external/slc6_amd64_gcc530
+git clone https://github.com/ikrav/RecoEgamma-ElectronIdentification.git data/RecoEgamma/ElectronIdentification/data
+cd data/RecoEgamma/ElectronIdentification/data
+git checkout egm_id_80X_v1
+cd $CMSSW_BASE/src
+scram b -j 8
+```

--- a/TTHAnalysis/cfg/run_susyMultilepton_cfg.py
+++ b/TTHAnalysis/cfg/run_susyMultilepton_cfg.py
@@ -55,7 +55,7 @@ lepAna.miniIsolationVetoLeptons = None # use 'inclusive' to veto inclusive lepto
 lepAna.doIsolationScan = False
 
 # Lepton Preselection
-lepAna.loose_electron_id = "POG_MVA_ID_Spring15_NonTrig_VLooseIdEmu"
+lepAna.loose_electron_id = "MVA_ID_NonTrig_Spring16_VLooseIdEmu"
 isolation = "miniIso"
 
 jetAna.copyJetsByValue = True # do not remove this
@@ -221,7 +221,8 @@ elif analysis=='SOS':
 
 # Spring16 electron MVA - follow instructions on pull request for correct area setup
 leptonTypeSusy.addVariables([
-        NTupleVariable("mvaIdSpring16",   lambda lepton : lepton.mvaRun2("Spring16") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID, Spring16; 1 for muons"),
+        NTupleVariable("mvaIdSpring16HZZ",   lambda lepton : lepton.mvaRun2("Spring16HZZ") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID, Spring16, HZZ; 1 for muons"),
+        NTupleVariable("mvaIdSpring16GP",   lambda lepton : lepton.mvaRun2("Spring16GP") if abs(lepton.pdgId()) == 11 else 1, help="EGamma POG MVA ID, Spring16, GeneralPurpose; 1 for muons"),
         ])
 
 if lepAna.doIsolationScan:


### PR DESCRIPTION
Requires CERN-PH-CMG/cmg-cmssw#681, adapting the calls to Electron.mvaRun2 to the naming change in the Spring16 electron MVA ID estimators.