### PR TITLE
Adding HEEP ID recalculation for Moriond

### DIFF
--- a/VVResonances/cfg/runVV_cfg.py
+++ b/VVResonances/cfg/runVV_cfg.py
@@ -93,7 +93,7 @@ triggerFlagsAna.triggerBits ={
 
 
 #-------- HOW TO RUN
-test = 0
+test = 1
 if test==1:
     # test a single component, using a single thread.
     selectedComponents = [BulkGravToWWToWlepWhad_narrow_2000]

--- a/VVResonances/interface/HEEPEleIDRecalculator.h
+++ b/VVResonances/interface/HEEPEleIDRecalculator.h
@@ -1,0 +1,103 @@
+#ifndef CMGTools_VVresonances_HEEPEleIdRecalculator_h
+#define CMGTools_VVresonances_HEEPEleIdRecalculator_h
+
+
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+
+
+namespace cmg {
+class HEEPEleIDRecalculator {
+ private:
+  struct TrkCuts {
+    float minPt;
+    float minDR2;
+    float maxDR2;
+    float minDEta;
+    float maxDZ;
+    float minHits;
+    float minPixelHits;
+    float maxDPtPt;
+    std::vector<reco::TrackBase::TrackQuality> allowedQualities;
+    std::vector<reco::TrackBase::TrackAlgorithm> algosToReject;
+  };  
+
+
+
+ public:
+  HEEPEleIDRecalculator() {
+    std::vector<std::string> empty;
+    setIsoCuts(true,1.0,0.0,0.3,0.005,0.5,8,1,0.1,empty,empty);
+    setIsoCuts(false,1.0,0.0,0.3,0.005,0.5,8,1,0.1,empty,empty);
+  }
+
+  ~HEEPEleIDRecalculator() {
+
+
+  }
+
+  bool id(const pat::Electron& e);
+  bool iso(const pat::Electron& e,const double rho, const std::vector<pat::Electron>& eles,const pat::PackedCandidateCollection& cands,const pat::PackedCandidateCollection& lostTracks);
+
+  void setIsoCuts(bool barrel,const double minPt,const double minDR,const double maxDR,const double minDEta,const double maxDZ,const int minHits,const int minPixelHits,const double maxDPtPt,const std::vector<std::string >& qualNames,const std::vector<std::string >& algoNames) {
+    auto sq = [](double val){return val*val;};
+    
+
+    TrkCuts cuts;
+    cuts.minDR2 = sq(minDR);
+    cuts.maxDR2 = sq(maxDR);
+    cuts.minDEta = minDEta;
+    cuts.maxDZ = maxDZ;
+    cuts.minHits = minHits;
+    cuts.minPixelHits = minPixelHits;
+    cuts.maxDPtPt = maxDPtPt;
+    
+    for(auto& qualName : qualNames){
+      cuts.allowedQualities.push_back(reco::TrackBase::qualityByName(qualName));
+    }
+    for(auto& algoName : algoNames){
+      cuts.algosToReject.push_back(reco::TrackBase::algoByName(algoName));
+    }
+    std::sort(cuts.algosToReject.begin(),cuts.algosToReject.end());
+    if (barrel)
+      barrelCuts_ = cuts;
+    else
+      endcapCuts_ = cuts;
+  }
+
+
+	       
+
+
+ private:
+  TrkCuts barrelCuts_,endcapCuts_;
+
+  static bool passTrkSel(const reco::Track& trk,
+			 const double trkPt,
+			 const TrkCuts& cuts,
+			 const double eleEta,const double elePhi,
+			 const double eleVZ);
+
+  static bool passQual(const reco::TrackBase& trk,
+		       const std::vector<reco::TrackBase::TrackQuality>& quals);
+
+  static bool passAlgo(const reco::TrackBase& trk,
+		       const std::vector<reco::TrackBase::TrackAlgorithm>& algosToRej);
+
+  double getTrkPt(const reco::TrackBase& trk,
+		  const std::vector<pat::Electron>& eles);
+
+
+
+  std::pair<int,double> calIsol(const double eleEta,const double elePhi,const double eleVZ,
+				const pat::PackedCandidateCollection& cands,
+				const std::vector<pat::Electron>& eles);
+
+
+};
+}
+#endif

--- a/VVResonances/python/analyzers/LeptonIDOverloader.py
+++ b/VVResonances/python/analyzers/LeptonIDOverloader.py
@@ -8,29 +8,23 @@ import PhysicsTools.HeppyCore.framework.config as cfg
 class LeptonIDOverloader( Analyzer ):
     def __init__(self, cfg_ana, cfg_comp, looperName):
         super(LeptonIDOverloader,self).__init__(cfg_ana, cfg_comp, looperName)
-
+        self.heepIDCalculator = ROOT.cmg.HEEPEleIDRecalculator()  
     def beginLoop(self, setup):
         super(LeptonIDOverloader,self).beginLoop(setup)
 
 
     def heepID(self,lepton):    
-#        for leptonid in lepton.electronIDs():
-#            print leptonid.first,leptonid.second
-        return lepton.electronID("heepElectronID-HEEPV60")>0.0
+        return self.heepIDNoIso(lepton) and self.heepIDCalculator.iso(lepton.physObj,lepton.rho,self.handles['electrons'].product(),self.handles['lostTracks'].product(),self.handles['packed'].product())
+
+    def declareHandles(self):
+        super(LeptonIDOverloader, self).declareHandles()
+        self.handles['packed'] = AutoHandle( 'packedPFCandidates', 'std::vector<pat::PackedCandidate>' )
+        self.handles['lostTracks'] = AutoHandle( 'lostTracks', 'std::vector<pat::PackedCandidate>' )
+        self.handles['electrons'] = AutoHandle( 'slimmedElectrons', 'std::vector<pat::Electron>' )
 
 
     def heepIDNoIso(self,e):
-        decisionBarrel = abs(e.superCluster().eta())<1.4442 and \
-            e.ecalDriven() and abs(e.deltaEtaSeedClusterTrackAtVtx())<0.004 and \
-            abs( e.deltaPhiSuperClusterTrackAtVtx())< 0.06 and (e.hadronicOverEm()<1.0/e.superCluster().energy()+0.05) and \
-            (e.e2x5Max()/e.e5x5()>0.94 or e.e1x5()/e.e5x5()>0.83) and abs(e.dxy())<0.02
-
-
-        decisionEndcap = abs(e.superCluster().eta())>1.566 and \
-            e.ecalDriven() and abs(e.deltaEtaSeedClusterTrackAtVtx())<0.006 and \
-            abs( e.deltaPhiSuperClusterTrackAtVtx())< 0.06 and (e.hadronicOverEm()<5.0/e.superCluster().energy()+0.05) and \
-            abs(e.dxy())<0.05 and e.full5x5_sigmaIetaIeta()<0.03
-        return decisionBarrel or decisionEndcap
+        return self.heepIDCalculator.id(e.physObj)
 
 
     def muonIDTrackerHighPt(self,mu):    
@@ -52,9 +46,6 @@ class LeptonIDOverloader( Analyzer ):
         
     def process(self, event):
         self.readCollections( event.input )
-#        for l in event.genleps:
-#            if l.pt()>30:
-#                print l.pdgId(),l.pt(),l.eta()
 
         for lepton in event.selectedLeptons:
             if abs(lepton.pdgId())==11:

--- a/VVResonances/src/HEEPEleIDRecalculator.cc
+++ b/VVResonances/src/HEEPEleIDRecalculator.cc
@@ -1,0 +1,132 @@
+#include "CMGTools/VVResonances/interface/HEEPEleIDRecalculator.h"
+
+using namespace cmg;
+bool HEEPEleIDRecalculator::id(const pat::Electron& e) {
+  if (fabs(e.superCluster()->eta()<1.4442)) 
+        return e.ecalDriven() && 
+	  fabs(e.deltaEtaSeedClusterTrackAtVtx())<0.004 &&
+            fabs( e.deltaPhiSuperClusterTrackAtVtx())< 0.06 &&
+	  (e.hadronicOverEm()<1.0/e.superCluster()->energy()+0.05) &&
+	  (e.e2x5Max()/e.e5x5()>0.94 || e.e1x5()/e.e5x5()>0.83) && fabs(e.dB())<0.02;
+
+  if (fabs(e.superCluster()->eta()>1.566)) 
+        return  fabs(e.superCluster()->eta())>1.566 &&
+	  e.ecalDriven() && fabs(e.deltaEtaSeedClusterTrackAtVtx())<0.006 &&
+	  fabs( e.deltaPhiSuperClusterTrackAtVtx())< 0.06 &&
+	  (e.hadronicOverEm()<5.0/e.superCluster()->energy()+0.05) &&
+	  fabs(e.dB())<0.05 && e.full5x5_sigmaIetaIeta()<0.03;
+
+  return false;
+}
+
+bool HEEPEleIDRecalculator::iso(const pat::Electron& e,const double rho, const std::vector<pat::Electron>& eles,const pat::PackedCandidateCollection& cands,const pat::PackedCandidateCollection& lostTracks) {
+   float trackIso = 0.0;
+   trackIso+=calIsol(e.gsfTrack()->eta(),e.gsfTrack()->phi(),e.gsfTrack()->vz(),cands,eles).second;
+   trackIso+=calIsol(e.gsfTrack()->eta(),e.gsfTrack()->phi(),e.gsfTrack()->vz(),lostTracks,eles).second;
+   if (trackIso>=5.0)
+     return false;
+
+   float neutralIso = e.dr03EcalRecHitSumEt()+e.dr03HcalDepth1TowerSumEt();
+  if (fabs(e.superCluster()->eta()<1.4442)) 
+    return neutralIso<2.0+0.03*e.et()+0.28*rho;
+
+  if (fabs(e.superCluster()->eta()<1.566)) {
+    if (e.et()<50.0) 
+      return neutralIso<2.5+0.28*rho;
+    else
+      return neutralIso<2.5+0.03*(e.et()-50.0)+0.28*rho;
+
+  }
+
+  return false;
+ }
+
+bool HEEPEleIDRecalculator::passQual(const reco::TrackBase& trk,
+	 const std::vector<reco::TrackBase::TrackQuality>& quals)
+{
+  if(quals.empty()) return true;
+
+  for(auto qual : quals) {
+    if(trk.quality(qual)) return true;
+  }
+
+  return false;  
+}
+
+bool HEEPEleIDRecalculator::
+passAlgo(const reco::TrackBase& trk,
+	 const std::vector<reco::TrackBase::TrackAlgorithm>& algosToRej)
+{
+  return algosToRej.empty() || !std::binary_search(algosToRej.begin(),algosToRej.end(),trk.algo());
+}
+
+//so the working theory here is that the track we have is the electrons gsf track
+//if so, lets get the pt of the gsf track before E/p combinations
+//if no match found to a gsf ele with a gsftrack, return the pt of the input track
+double HEEPEleIDRecalculator::
+getTrkPt(const reco::TrackBase& trk,
+	 const std::vector<pat::Electron>& eles)
+{
+  //note, the trk.eta(),trk.phi() should be identical to the gsf track eta,phi
+  //although this may not be the case due to roundings after packing
+  auto match=[](const reco::TrackBase& trk,const pat::Electron& ele){
+    return std::abs(trk.eta()-ele.gsfTrack()->eta())<0.001 &&
+    reco::deltaPhi(trk.phi(),ele.gsfTrack()->phi())<0.001;// && 
+  };
+  for(auto& ele : eles){
+    if(ele.gsfTrack().isNonnull()){
+      if(match(trk,ele)){
+	return ele.gsfTrack()->pt();
+      }
+    }
+  }
+  return trk.pt();
+}
+
+
+
+
+std::pair<int,double> 
+HEEPEleIDRecalculator::calIsol(const double eleEta,const double elePhi,
+			    const double eleVZ,
+			    const pat::PackedCandidateCollection& cands,
+			       const std::vector<pat::Electron>& eles)
+{
+
+  double ptSum=0.;
+  int nrTrks=0;
+
+  const TrkCuts& cuts = std::abs(eleEta)<1.5 ? barrelCuts_ : endcapCuts_;
+  
+  for(auto& cand  : cands){
+    if(cand.charge()!=0){
+      const reco::Track& trk = cand.pseudoTrack(); 
+      double trkPt = std::abs(cand.pdgId())!=11 ? trk.pt() : getTrkPt(trk,eles);
+      if(passTrkSel(trk,trkPt,cuts,eleEta,elePhi,eleVZ)){
+	ptSum+=trkPt;
+	nrTrks++;
+      }
+    }
+  }
+  return {nrTrks,ptSum};
+}
+
+bool HEEPEleIDRecalculator::passTrkSel(const reco::Track& trk,
+				    const double trkPt,const TrkCuts& cuts,
+				    const double eleEta,const double elePhi,
+				    const double eleVZ)
+{
+  const float dR2 = reco::deltaR2(eleEta,elePhi,trk.eta(),trk.phi());
+  const float dEta = trk.eta()-eleEta;
+  const float dZ = eleVZ - trk.vz();
+
+  return dR2>=cuts.minDR2 && dR2<=cuts.maxDR2 && 
+    std::abs(dEta)>=cuts.minDEta && 
+    std::abs(dZ)<cuts.maxDZ &&
+    trk.hitPattern().numberOfValidHits() >= cuts.minHits &&
+    trk.hitPattern().numberOfValidPixelHits() >=cuts.minPixelHits &&
+    (trk.ptError()/trkPt < cuts.maxDPtPt || cuts.maxDPtPt<0) && 
+    passQual(trk,cuts.allowedQualities) &&
+    passAlgo(trk,cuts.algosToReject) &&
+    trkPt > cuts.minPt;
+}

--- a/VVResonances/src/classes.h
+++ b/VVResonances/src/classes.h
@@ -2,6 +2,7 @@
 #include "CMGTools/VVResonances/interface/CandidateBoostedDoubleSecondaryVertexComputerLight.h"
 #include "CMGTools/VVResonances/interface/IPProducerLight.h"
 #include "CMGTools/VVResonances/interface/SecondaryVertexProducerLight.h"
+#include "CMGTools/VVResonances/interface/HEEPEleIDRecalculator.h"
 
 namespace cmg{
 
@@ -10,5 +11,6 @@ namespace cmg{
     cmg::CandidateBoostedDoubleSecondaryVertexComputerLight candidateBoostedDoubleSecondaryVertexComputerLight;
     cmg::IPProducerLight ipProducerLight;
     cmg::IPProducerLight secondaryVertexProducerLight;
+    cmg::HEEPEleIDRecalculator heepRecalc;
   };
 }

--- a/VVResonances/src/classes_def.xml
+++ b/VVResonances/src/classes_def.xml
@@ -3,4 +3,6 @@
   <class name="cmg::CandidateBoostedDoubleSecondaryVertexComputerLight"  transient="true"/>
   <class name="cmg::IPProducerLight"  transient="true"/>
   <class name="cmg::SecondaryVertexProducerLight"  transient="true"/>
+  <class name="cmg::HEEPEleIDRecalculator"  transient="true"/>
+
 </lcgdict>


### PR DESCRIPTION
@clelange  This should be fine . I changed the LeptonID Overloader to use the recalculation 
stuff . Now I have not tested it event by event against the full CMSSW because I dont know how 
to use the VID stuff . If you see differences in sync there could be two sources 
1. The neutral isolation uses ET of supercluster and not electron.et() [if thats the case we can change]
2.The dxy() is different than the patElectron.dB() that I used and we need to recalculate it 
In both cases minor changed to the HEEPEleIDCalculator can fix those 
