### PR TITLE
add flag to allow downloadTreesFromEOS to continue download if indivi…

### DIFF
--- a/Production/scripts/downloadTreesFromEOS.py
+++ b/Production/scripts/downloadTreesFromEOS.py
@@ -15,8 +15,9 @@ if __name__ == "__main__":
 	parser = OptionParser(usage=usage)
 	parser.add_option("-t", dest="treeproducername", type='string', default="myTreeProducer", help='Name of the tree producer module')
 	parser.add_option("-T", dest="treename", type='string', default="tree.root", help='Name of the tree file')
+	parser.add_option("-c", "--continue", dest="continueCopy", action="store_true", default=False, help='Continue downloading if a chunk failed and print a summary at the end')
 	(options, args) = parser.parse_args()
-	
+
 	locdir = args[0]
 	chunks = eostools.ls(locdir)
 
@@ -28,6 +29,7 @@ if __name__ == "__main__":
 	print 'Will operate on the following chunks:',chunks
 
 	tocopy = []
+	failedDict = {}
 	for d in chunks:
 		f = '%s/%s/%s'%(d,options.treeproducername,options.treename)
 		furl = '%s.url'%f
@@ -35,10 +37,20 @@ if __name__ == "__main__":
 			print 'Chunk %s already contains tree root file %s, skipping'%(d,f)
 			continue
 		if not os.path.exists(furl):
-			raise RuntimeError,'Chunk %s does not contain url file %s'%(d,furl)
+			if (options.continueCopy):
+				print 'Chunk %s does not contain url file %s' % (d, furl)
+				failedDict[d] = furl
+				continue
+			else:
+				raise RuntimeError,'Chunk %s does not contain url file %s'%(d,furl)
 		with open(furl,'r') as _furl:
 			rem = _furl.readline().replace('root://eoscms.cern.ch/','').replace('\n','')
 			if not eostools.isFile(rem):
 				raise RuntimeError,'Remote file %s not found'%rem
 			eostools.xrdcp(rem,f)
 
+	if (options.continueCopy and (len(failedDict.keys()) > 0)):
+		print "="*100
+		print "Summary of failed download attempts (%d in total):" % len(failedDict.keys())
+		for d, furl in failedDict.iteritems():
+			print 'Chunk %s does not contain url file %s' % (d, furl)


### PR DESCRIPTION
…dual chunks failed.
Prints info while downloading and a summary at the end. Does not change default behaviour of script. This allows downloading in parallel to running jobs.