### PR TITLE
check hasTrackDetails for PackedCandidates before accessing PseudoTrack

### DIFF
--- a/VVResonances/src/HEEPEleIDRecalculator.cc
+++ b/VVResonances/src/HEEPEleIDRecalculator.cc
@@ -99,7 +99,7 @@ HEEPEleIDRecalculator::calIsol(const double eleEta,const double elePhi,
         const TrkCuts& cuts = std::abs(eleEta)<1.5 ? barrelCuts_ : endcapCuts_;
 
         for(auto& cand  : cands) {
-                if(cand.charge()!=0) {
+                if(cand.charge()!=0 && cand.hasTrackDetails()) {
                         const reco::Track& trk = cand.pseudoTrack();
                         double trkPt = std::abs(cand.pdgId())!=11 ? trk.pt() : getTrkPt(trk,eles);
                         if(passTrkSel(trk,trkPt,cuts,eleEta,elePhi,eleVZ)) {


### PR DESCRIPTION
This is required for the code to work in 94X (tested on 2k events of BulkG WW signal sample)