### PR TITLE
Condor submission

### DIFF
--- a/Production/scripts/cmgListChunksToResub
+++ b/Production/scripts/cmgListChunksToResub
@@ -13,7 +13,7 @@ LSFL=false
 F=JSONAnalyzer/JSON.pck
 LOC=false
 P=false
-Q=8nh
+Q=""
 Z=false
 
 # evaluate parameters
@@ -25,7 +25,7 @@ while true; do
     -t )            F="$2"; shift 2 ;;
     -l )            LOC=true; shift ;;
     -p )            P=true; shift ;;
-    -q )            Q="$2"; shift 2 ;;
+    -q )            Q="-q $2"; shift 2 ;;
     -z )            Z=true; shift ;;
     -- )            shift; break ;;
     *  )            break ;;
@@ -92,7 +92,7 @@ for D in */; do
                 echo "cmgRunChunkLocally ${BASE}${D} ";
 	        else
                 # print batch command
-		        echo "cmgResubChunk -q $Q ${BASE}${D} ";
+		        echo "cmgResubChunk $Q ${BASE}${D} ";
             fi
         else
             $TERSE || echo "# Chunk ${BASE}${D} does not have a LSFJOB directory, maybe still running? ";
@@ -108,7 +108,7 @@ if $Z; then
             if $LOC; then
                 echo "cmgRunChunkLocally ${BASE}${D}     # zombie";
             else
-                echo "cmgResubChunk -q $Q ${BASE}${D}    # zombie";
+                echo "cmgResubChunk $Q ${BASE}${D}    # zombie";
             fi
         fi;
     done

--- a/Production/scripts/cmgResubChunk
+++ b/Production/scripts/cmgResubChunk
@@ -20,4 +20,9 @@ fi
 LAB="$(basename $PWD)"; if [[ "$1" != "" ]]; then LAB=$1; fi;
 rename LSFJ OLD_LSFJ *; 
 test -f submission_failed && rm submission_failed
-bsub -q $Q -J $LAB < batchScript.sh
+
+if [[ "$Q" != "" ]]; then
+    bsub -q $Q -J $LAB < batchScript.sh;
+else; then
+    run_condor.sh batchScript.sh
+fi;

--- a/Production/scripts/cmgResubChunk
+++ b/Production/scripts/cmgResubChunk
@@ -7,7 +7,7 @@ if [[ "$1" == "" || "$1" == "-h" || "$1" == "--help" ]]; then
     exit 1;
 fi
 
-Q=2nd
+Q=""
 if [[ "$1" == "-q" ]]; then
     Q=$2; shift; shift;
 fi;
@@ -21,8 +21,8 @@ LAB="$(basename $PWD)"; if [[ "$1" != "" ]]; then LAB=$1; fi;
 rename LSFJ OLD_LSFJ *; 
 test -f submission_failed && rm submission_failed
 
-if [[ "$Q" != "" ]]; then
-    bsub -q $Q -J $LAB < batchScript.sh;
-else; then
+if [ "$Q" != "" ]; then
+    bsub -q $Q -J $LAB < batchScript.sh
+else
     run_condor.sh batchScript.sh
 fi;


### PR DESCRIPTION
Requires: https://github.com/CERN-PH-CMG/cmg-cmssw/pull/713

Condor submission tools. At CERN the standard batch submission goes to condor (instead of LSF). Standard workflow:

```
heppy_batch.py $CFG -o $OUTDIR
heppy_untarcfg.py $OUTDIR
heppy_check.py $OUTDIR/*
cmgListChunksToResub $OUTDIR > resub.sh
sh resub.sh
```

These tools/scripts are modified versions of those used in the alphaT analysis for condor submission at Bristol.