### PR TITLE
use os.path instead of eostools to check for existence on mounted eos…

### DIFF
--- a/Production/scripts/downloadTreesFromEOS.py
+++ b/Production/scripts/downloadTreesFromEOS.py
@@ -45,7 +45,7 @@ if __name__ == "__main__":
 				raise RuntimeError,'Chunk %s does not contain url file %s'%(d,furl)
 		with open(furl,'r') as _furl:
 			rem = _furl.readline().replace('root://eoscms.cern.ch/','').replace('\n','')
-			if not eostools.isFile(rem):
+			if not os.path.isfile(rem):
 				raise RuntimeError,'Remote file %s not found'%rem
 			eostools.xrdcp(rem,f)
 


### PR DESCRIPTION
… path

This makes the script work again if the project directory is e.g. on afs and the output dir is somewhere on `/eos`