### PR TITLE
support for prescaling skim, and implementation for ttH leptonic

### DIFF
--- a/TTHAnalysis/cfg/run_ttH_cfg.py
+++ b/TTHAnalysis/cfg/run_ttH_cfg.py
@@ -625,6 +625,18 @@ if getHeppyOption("prescale"):
         sequence.insert(sequence.index(jsonAna)+1, thePrescale)
     else:
         sequence.insert(sequence.index(skimAnalyzer)+1, thePrescale)
+if getHeppyOption("prescaleskim"):
+    from CMGTools.TTHAnalysis.analyzers.ttHPrescalingLepSkimmer import ttHPrescalingLepSkimmer
+    psvalue = 10 #int( getHeppyOption("prescaleskim") ) if getHeppyOption("preskim") != True else 10
+    if psvalue <= 1: raise RuntimeError
+    thePreskim = cfg.Analyzer(ttHPrescalingLepSkimmer, name="ttHPrescalingLepSkimmer", 
+            minLeptons = 2, requireSameSignPair = True,
+            jetSelection = lambda jet : jet.pt()*max(1,jet.corrJECUp/jet.corr,jet.corrJECDown/jet.corr) > 25,
+            minJets = 4, 
+            minMET = 70,
+            prescaleFactor = psvalue,
+            useEventNumber = True)
+    sequence.insert(sequence.index(metAna)+1, thePreskim)
 
 if not getHeppyOption("keepLHEweights",False):
     if "LHE_weights" in treeProducer.collections: treeProducer.collections.pop("LHE_weights")

--- a/TTHAnalysis/cfg/validate_multilep.sh
+++ b/TTHAnalysis/cfg/validate_multilep.sh
@@ -45,6 +45,7 @@ function do_plot {
     ( cd ../python/plotter;
       # ---- MCA ---
       MCA=susy-multilepton/validation_mca.txt
+      if echo $PROC | grep -q Run201[2567]; then MCA=susy-multilepton/validation-data_mca.txt; fi;
       # ---- CUT FILE ---
       CUTS=susy-multilepton/validation.txt;
       if [ -f susy-multilepton/validation-${PROC}.txt ]; then 
@@ -58,8 +59,9 @@ function do_plot {
              CUTS=susy-multilepton/validation-data.txt
         fi;
       fi
+      WA=1; if echo $WHAT | grep -q Presc; then WA=prescaleFromSkim; fi;
       python mcPlots.py -f --s2v --tree treeProducerSusyMultilepton  -P ${DIR} $MCA $CUTS ${CUTS/.txt/_plots.txt} \
-              --pdir plots/94X/validation/${OUTNAME} -p new,ref -u -e \
+              --pdir plots/94X/validation/${OUTNAME}  -u -e --WA $WA \
               --plotmode=nostack --showRatio --maxRatioRange 0.65 1.35 --flagDifferences
     );
 }
@@ -86,14 +88,19 @@ case $WHAT in
     ttHMCSize)
         $RUN && do_run run_ttH_cfg.py $DIR -o test=94X-MC -o sample=TTLep -o fast;
         do_size TTLep_pow
-        do_plot TTLep_pow TTLep_pow big
+        do_plot TTLep_pow TTLep_pow _big
         ;;
     ttHDataSize)
         $RUN && do_run run_ttH_cfg.py $DIR -o test=94X-Data  -N 100000 -o runData -o fast;
         do_size DoubleMuon_Run2017C 
         do_size DoubleEG_Run2017E
-        do_plot DoubleMuon_Run2017C DoubleMuon_Run2017C big
-        do_plot DoubleEG_Run2017E DoubleEG_Run2017E big
+        do_plot DoubleMuon_Run2017C DoubleMuon_Run2017C _big
+        do_plot DoubleEG_Run2017E DoubleEG_Run2017E _big
+        ;;
+    ttHDataPresc)
+        $RUN && do_run run_ttH_cfg.py $DIR -o test=94X-Data  -N 100000 -o runData -o fast -o prescaleskim;
+        do_plot DoubleMuon_Run2017C DoubleMuon_Run2017C _big
+        do_plot DoubleEG_Run2017E DoubleEG_Run2017E _big
         ;;
     ttHData80X)
         $RUN && do_run run_ttH_cfg.py $DIR -o test=80X-Data  -N 10000 -o runData -o run80X;

--- a/TTHAnalysis/python/analyzers/treeProducerTTH.py
+++ b/TTHAnalysis/python/analyzers/treeProducerTTH.py
@@ -69,6 +69,8 @@ ttH_globalVariables = [
             NTupleVariable("nLepGood20", lambda ev: sum([l.pt() > 20 for l in ev.selectedLeptons]), int, help="Number of leptons with pt > 20"),
             NTupleVariable("nLepGood15", lambda ev: sum([l.pt() > 15 for l in ev.selectedLeptons]), int, help="Number of leptons with pt > 15"),
             NTupleVariable("nLepGood10", lambda ev: sum([l.pt() > 10 for l in ev.selectedLeptons]), int, help="Number of leptons with pt > 10"),
+            ##--------------------------------------------------
+            NTupleVariable("prescaleFromSkim", lambda ev : getattr(ev, "prescaleFromSkim", 1), help="event prescale from the skimming module"),
 ]
 
 ttH_globalObjects = {

--- a/TTHAnalysis/python/analyzers/ttHPrescalingLepSkimmer.py
+++ b/TTHAnalysis/python/analyzers/ttHPrescalingLepSkimmer.py
@@ -1,0 +1,80 @@
+from PhysicsTools.Heppy.analyzers.core.Analyzer import Analyzer
+
+import itertools
+
+class ttHPrescalingLepSkimmer( Analyzer ):
+    def __init__(self, cfg_ana, cfg_comp, looperName ):
+        super(ttHPrescalingLepSkimmer,self).__init__(cfg_ana,cfg_comp,looperName)
+        self.prescaleFactor = cfg_ana.prescaleFactor
+        self.useEventNumber = getattr(cfg_ana,'useEventNumber',True)
+        self.leptons    = getattr(cfg_ana, 'leptons', "selectedLeptons")
+        self.leptonSel  = getattr(cfg_ana, 'leptonSelection', None)
+        self.minLeptons = getattr(cfg_ana, 'minLeptons', 0)
+        self.requireSameSignPair = getattr(cfg_ana,"requireSameSignPair",False)
+        self.jets    = getattr(cfg_ana, 'jets', "cleanJets")
+        self.jetSel  = getattr(cfg_ana, 'jetSelection', None)
+        self.minJets = getattr(cfg_ana, 'minJets', 0)
+        self.met    = getattr(cfg_ana, 'met', "met")
+        self.minMET = getattr(cfg_ana, 'minMET', 0)
+        self.label  = getattr(cfg_ana, 'label', "prescaleFromSkim")
+        self.events = 0
+
+    def declareHandles(self):
+        super(ttHPrescalingLepSkimmer, self).declareHandles()
+
+    def beginLoop(self, setup):
+        super(ttHPrescalingLepSkimmer,self).beginLoop(setup)
+        self.counters.addCounter('events')
+        count = self.counters.counter('events')
+        count.register('all events')
+        count.register('accepted (unity / leptons)')
+        count.register('accepted (unity / same-sign leps)')
+        count.register('accepted (unity / jets)')
+        count.register('accepted (unity / met)')
+        count.register('accepted (unity)')
+        count.register('tested   (prescaled)')
+        count.register('accepted (prescaled)')
+
+
+    def process(self, event):
+        counters = self.counters.counter('events')
+        counters.inc('all events')
+        toBePrescaled = True
+        if self.minLeptons > 0:
+            leps = getattr(event, self.leptons)
+            if self.leptonSel: leps = filter(self.leptonSel, leps)
+            if len(leps) >= self.minLeptons:
+                if self.requireSameSignPair:
+                    if any([(l1.charge() * l2.charge() > 0) for l1,l2 in itertools.combinations(leps,2)]):
+                        toBePrescaled = False
+                        counters.inc('accepted (unity / same-sign leps)')
+                else:
+                    toBePrescaled = False
+                    counters.inc('accepted (unity / leptons)')
+        if self.minJets > 0:
+            jets = getattr(event, self.jets)
+            if self.jetSel: jets = filter(self.jetSel, jets)
+            if len(jets) >= self.minJets:
+                toBePrescaled = False
+                counters.inc('accepted (unity / jets)')
+        if self.minMET > 0:
+            met = getattr(event, self.met)
+            if met.pt() > self.minMET:
+                toBePrescaled = False
+                counters.inc('accepted (unity / met)')
+        if not toBePrescaled:
+            counters.inc('accepted (unity)')
+            setattr(event, self.label, 1)
+            return True
+        counters.inc('tested   (prescaled)')
+        self.events += 1
+        evno = self.events
+        if self.useEventNumber: # use run and LS number multiplied by some prime numbers
+            evno = event.input.eventAuxiliary().id().event()*223 + event.input.eventAuxiliary().id().luminosityBlock()*997
+        if (evno % self.prescaleFactor == 1):
+            counters.inc('accepted (prescaled)')
+            setattr(event, self.label, self.prescaleFactor)
+            return True
+        else:
+            return False
+

--- a/TTHAnalysis/python/plotter/susy-multilepton/validation-data_mca.txt
+++ b/TTHAnalysis/python/plotter/susy-multilepton/validation-data_mca.txt
@@ -1,0 +1,2 @@
+data_new  : New : 1 ; FillColor=ROOT.kOrange+10
+data_ref+ : Ref : 1 ; FillColor=ROOT.kAzure+2, Label="Ref."

--- a/TTHAnalysis/python/plotter/tree2yield.py
+++ b/TTHAnalysis/python/plotter/tree2yield.py
@@ -423,7 +423,7 @@ class TreeToYield:
         if self._options.doS2V:
             cut  = scalarToVector(cut)
         if self._weightStringAll != "1":
-            cut = "(%s)*%s" % (self._weightStringAll, cut)
+            cut = "(%s)*(%s)" % (self._weightStringAll, cut)
         return cut
     def _getYield(self,tree,cut,fsplit=None,cutNeedsPreprocessing=True):
         cut = self._getCut(cut) if cutNeedsPreprocessing else cut
@@ -505,7 +505,7 @@ class TreeToYield:
         else:
             cut = self.adaptExpr(cut,cut=True)
         if self._weightStringAll != "1":
-            cut = "(%s)*%s" % (self._weightStringAll, cut)
+            cut = "(%s)*(%s)" % (self._weightStringAll, cut)
         return cut
     def getPlotRaw(self,name,expr,bins,cut,plotspec,fsplit=None,closeTreeAfter=False):
         unbinnedData2D = plotspec.getOption('UnbinnedData2D',False) if plotspec != None else False
@@ -593,7 +593,7 @@ class TreeToYield:
             else:            cut = "(%s)*(%s)*(%s)*(%s)" % (self._weightString,self._options.lumi, self._scaleFactor, self.adaptExpr(cut,cut=True))
         else: cut = self.adaptExpr(cut,cut=True)
         if self._options.doS2V: cut  = scalarToVector(cut)
-        if self._weightStringAll != "1": cut = "(%s)*%s" % (self._weightStringAll, cut)
+        if self._weightStringAll != "1": cut = "(%s)*(%s)" % (self._weightStringAll, cut)
         (firstEntry, maxEntries) = self._rangeToProcess(fsplit)
         self._tree.Draw('>>elist', cut, 'entrylist', maxEntries, firstEntry)
         elist = ROOT.gDirectory.Get('elist')

--- a/TTHAnalysis/python/plotter/tree2yield.py
+++ b/TTHAnalysis/python/plotter/tree2yield.py
@@ -144,6 +144,7 @@ class TreeToYield:
         self._objname = objname if objname else options.obj
         self._weight  = (options.weight and 'data' not in self._name )
         self._isdata = 'data' in self._name
+        self._weightStringAll  = options.weightStringAll
         self._weightString0  = options.weightString if not self._isdata else "1"
         self._scaleFactor0  = scaleFactor
         self._fullYield = 0 # yield of the full sample, as if it passed the full skim and all cuts
@@ -421,10 +422,12 @@ class TreeToYield:
             cut = self.adaptExpr(cut,cut=True)
         if self._options.doS2V:
             cut  = scalarToVector(cut)
+        if self._weightStringAll != "1":
+            cut = "(%s)*%s" % (self._weightStringAll, cut)
         return cut
     def _getYield(self,tree,cut,fsplit=None,cutNeedsPreprocessing=True):
         cut = self._getCut(cut) if cutNeedsPreprocessing else cut
-        if self._weight:
+        if self._weight or (self._weightStringAll != "1"):
 #            print cut
             ROOT.gROOT.cd()
             if ROOT.gROOT.FindObject("dummy") != None: ROOT.gROOT.FindObject("dummy").Delete()
@@ -501,6 +504,8 @@ class TreeToYield:
             else:            cut = "(%s)*(%s)*(%s)*(%s)" % (self._weightString,self._options.lumi, self._scaleFactor, self.adaptExpr(cut,cut=True))
         else:
             cut = self.adaptExpr(cut,cut=True)
+        if self._weightStringAll != "1":
+            cut = "(%s)*%s" % (self._weightStringAll, cut)
         return cut
     def getPlotRaw(self,name,expr,bins,cut,plotspec,fsplit=None,closeTreeAfter=False):
         unbinnedData2D = plotspec.getOption('UnbinnedData2D',False) if plotspec != None else False
@@ -588,6 +593,7 @@ class TreeToYield:
             else:            cut = "(%s)*(%s)*(%s)*(%s)" % (self._weightString,self._options.lumi, self._scaleFactor, self.adaptExpr(cut,cut=True))
         else: cut = self.adaptExpr(cut,cut=True)
         if self._options.doS2V: cut  = scalarToVector(cut)
+        if self._weightStringAll != "1": cut = "(%s)*%s" % (self._weightStringAll, cut)
         (firstEntry, maxEntries) = self._rangeToProcess(fsplit)
         self._tree.Draw('>>elist', cut, 'entrylist', maxEntries, firstEntry)
         elist = ROOT.gDirectory.Get('elist')
@@ -632,6 +638,7 @@ def addTreeToYieldOptions(parser):
     parser.add_option("-u", "--unweight",       dest="weight",       action="store_false", default=True, help="Don't use weights (in MC events), note weights are still used if a fake rate file is given");
     parser.add_option("--uf", "--unweight-forced",  dest="forceunweight", action="store_true", default=False, help="Do not use weight even if a fake rate file is given.");
     parser.add_option("-W", "--weightString",   dest="weightString", type="string", default="1", help="Use weight (in MC events)");
+    parser.add_option("--WA", "--weightAll",   dest="weightStringAll", type="string", default="1", help="Use this weight on all events (including data)");
     parser.add_option("-f", "--final",  dest="final", action="store_true", help="Just compute final yield after all cuts");
     parser.add_option("-e", "--errors",  dest="errors", action="store_true", help="Include uncertainties in the reports");
     parser.add_option("--tf", "--text-format",   dest="txtfmt", type="string", default="text", help="Output format: text, html");


### PR DESCRIPTION
 * Skimming module that prescales events that fail the selection instead of simply rejecting them. The prescale for the event is saved in the event, so that events can be upweighted in the plots. 
    * This can allow to reduce the size of the trees but without loosing statistical power in the signal region or tails, and without having to use separate trees for signal region and control regions
 * Added in mcAnalysis tools support for applying a weight to all events, including data (`--WA`), that can be used to plot using the prescale from the above module.


In the ttH configuration (2 same-sign leptons or >= 4 jets before lepton cleaning or met > 80), and prescale factor 10, the skimming efficiency is:
 *  20-25% on DoubleLepton PDs (13-15% from unprescaled events, rest from prescaled ones)
 * ~20% on DY MC (11% unprescaled, 9% prescaled)
 * ~90% on TTbar di-leptonic MC (mainly from unprescaled events)