### PR TITLE
explicit error message when grid-proxy-init is not set

### DIFF
--- a/Production/python/dataset.py
+++ b/Production/python/dataset.py
@@ -246,7 +246,12 @@ class CMSDataset( BaseDataset ):
         if dbsInstance != None:
             query += "  instance=prod/%s" % dbsInstance
         dbs='dasgoclient --query="summary %s=%s" --format=json'%(qwhat,query)
-        jdata = json.load(_dasPopen(dbs))['data']
+        try:
+            jdata = json.load(_dasPopen(dbs))['data']
+        except ValueError as err:
+            err=['cannot decode json obtained from das']
+            err.append(_dasPopen(dbs).read())
+            raise ValueError('\n'.join(err))
         events = []
         files = []
         lumis = []


### PR DESCRIPTION
Hello, 

When the grid proxy is not set, the json obtained from das cannot be decoded as the returned file from das actually contains the das error message. Here is a small modification that gives an explicit error message to the user. (if you want me to PR to another branch instead, just tell me)

Cheers,

Colin