### PR TITLE
Get a running cmgtools-lite branch in 10_4_X

### DIFF
--- a/TTHAnalysis/cfg/validate_multilep.sh
+++ b/TTHAnalysis/cfg/validate_multilep.sh
@@ -61,13 +61,13 @@ function do_plot {
       fi
       WA=1; if echo $WHAT | grep -q Presc; then WA=prescaleFromSkim; fi;
       python mcPlots.py -f --s2v --tree treeProducerSusyMultilepton  -P ${DIR} $MCA $CUTS ${CUTS/.txt/_plots.txt} \
-              --pdir plots/94X/validation/${OUTNAME}  -u -e --WA $WA \
+              --pdir plots/104X/validation/${OUTNAME}  -u -e --WA $WA \
               --plotmode=nostack --showRatio --maxRatioRange 0.65 1.35 --flagDifferences
     );
 }
 function do_size {
     PROC=$1; SUB=$2; 
-    perl /afs/cern.ch/user/g/gpetrucc/pl/treeSize.pl $DIR/$PROC/treeProducerSusyMultilepton/tree.root > ../python/plotter/plots/94X/validation/treeSize/${PROC}${SUB}.html
+    perl /afs/cern.ch/user/g/gpetrucc/pl/treeSize.pl $DIR/$PROC/treeProducerSusyMultilepton/tree.root > ../python/plotter/plots/104X/validation/treeSize/${PROC}${SUB}.html
 }
 
 

--- a/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
+++ b/TTHAnalysis/python/analyzers/susyCore_modules_cff.py
@@ -222,7 +222,7 @@ lepAna = cfg.Analyzer(
     # electron isolation correction method (can be "rhoArea" or "deltaBeta")
     ele_isoCorr = "rhoArea" ,
     ele_effectiveAreas = "Fall17" , #(can be 'Data2012' or 'Phys14_25ns_v1' or 'Spring15_25ns_v1')
-    ele_tightId = "Cuts_2012" ,
+    ele_tightId = "Cuts_SPRING15_25ns_v1_ConvVetoDxyDz" ,
     # Mini-isolation, with pT dependent cone: will fill in the miniRelIso, miniRelIsoCharged, miniRelIsoNeutral variables of the leptons (see https://indico.cern.ch/event/368826/ )
     doMiniIsolation = False, # off by default since it requires access to all PFCandidates 
     packedCandidates = 'packedPFCandidates',

--- a/TTHAnalysis/python/plotter/tree2yield.py
+++ b/TTHAnalysis/python/plotter/tree2yield.py
@@ -12,6 +12,7 @@ import ROOT
 sys.argv = args
 ROOT.gROOT.SetBatch(True)
 ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gSystem.Load("libpng") # otherwise we may end up with a bogus version
 
 from copy import *
 

--- a/VVResonances/interface/CandidateBoostedDoubleSecondaryVertexComputerLight.h
+++ b/VVResonances/interface/CandidateBoostedDoubleSecondaryVertexComputerLight.h
@@ -2,7 +2,7 @@
 #define CMGTools_VVResonances_CandidateBoostedDoubleSecondaryVertexComputerLight_h
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "CommonTools/Utils/interface/TMVAEvaluator.h"
+#include "CommonTools/MVAUtils/interface/TMVAEvaluator.h"
 #include "DataFormats/JetReco/interface/JetCollection.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"


### PR DESCRIPTION
Based on `heppy_104X_dev`, which includes the new electron ID FWLite code from https://github.com/CERN-PH-CMG/cmg-cmssw/pull/752 (the E/gamma part was already in the release)

Getting a working 10_2_X setup for the electron ID is a mess since 10_2_X is largely different both from the old 9_4_X and 94X + new fwlite electron ID.
There seems to be still some small regressions wrt 94X+752 to be further investigated but it looks usable ( plots at https://gpetrucc.web.cern.ch/gpetrucc/drop/plots/ttH/104X/validation/ttHMC-TTLep_pow/ )